### PR TITLE
Explicitly require 'stringio'

### DIFF
--- a/lib/test_queue/runner/minitest.rb
+++ b/lib/test_queue/runner/minitest.rb
@@ -1,5 +1,6 @@
 require 'test_queue/runner'
 require 'minitest/unit'
+require 'stringio'
 
 class MiniTestQueueRunner < MiniTest::Unit
   def _run_suites(*)


### PR DESCRIPTION
I believe this is necessary unless test-queue is running from inside a context where StringIO's already been pulled in.
