### PR TITLE
Updates the readme example with a call to super

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ class MyAppTestRunner < TestQueue::Runner::MiniTest
     # use separate redis database
     $redis.client.db = num
     $redis.client.reconnect
+    super
   end
 
   def prepare(concurrency)


### PR DESCRIPTION
`super` is critical for test-queue internals to work properly. I bashed
my head against my codebase for an hour before I realized it.
