### PR TITLE
Ignore the ParallelEach changes when running Minitest4

### DIFF
--- a/lib/test_queue/runner/minitest4.rb
+++ b/lib/test_queue/runner/minitest4.rb
@@ -2,9 +2,17 @@ require 'test_queue/runner'
 require 'stringio'
 
 class MiniTestQueueRunner < MiniTest::Unit
-  def _run_suites(*)
+  def _run_suites(suites, type)
     self.class.output = $stdout
-    super
+
+    if defined?(ParallelEach)
+      # Ignore its _run_suites implementation since we don't handle it gracefully.
+      # If we don't do this #partition is called on the iterator and all suites
+      # distributed immediately, instead of picked up as workers are available.
+      suites.map { |suite| _run_suite suite, type }
+    else
+      super
+    end
   end
 
   def _run_anything(*)


### PR DESCRIPTION
Hi there!

Updating our app to rails 4.0 has messed up with our test-queue setup a bit. After the update there'd be some workers that would finish really quick and others that would take ages.

Digging a bit I found out that Rails 4 automatically requires minitest/parallel_each ([first this](https://github.com/rails/rails/blob/v4.0.10/activesupport/lib/active_support/test_case.rb#L9) and [then this](https://github.com/rails/rails/blob/v4.0.10/activesupport/lib/active_support/testing/isolation.rb#L2)). 

That changes `_run_suites` to [call partition first](https://github.com/seattlerb/minitest/blob/644a52fd0aa0205c8767829ca8afbd8c158f9ff2/lib/minitest/parallel_each.rb#L62), which exhausts the iterator. That means all suites are distributed at the beginning instead of being
pulled as workers are available.

I see the minitest5 runner does seem to handle all these parallel test_order tests much better, so I figure out this problem only affects rails 4.0 with minitest 4.

What do you think of this solution? It does the trick in our case.
