### PR TITLE
Fix empty slave message issue

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -193,7 +193,7 @@ module TestQueue
       return unless relay?
 
       sock = connect_to_relay
-      message = " #{@slave_message}" if @slave_message
+      message = @slave_message ? " #{@slave_message}" : ""
       message.gsub!(/(\r|\n)/, "") # Our "protocol" is newline-separated
       sock.puts("SLAVE #{@concurrency} #{Socket.gethostname} #{@run_token}#{message}")
       response = sock.gets.strip


### PR DESCRIPTION
I'm not exactly sure what happened but it seems there's a case of empty slave message and it causes an exception.

The stack trace is here.
```
xxx/lib/test_queue/runner.rb:197:in `start_relay': undefined method `gsub!' for nil:NilClass (NoMethodError)
	from xxx/lib/test_queue/runner.rb:159:in `execute_parallel'
	from xxx/lib/test_queue/runner.rb:94:in `execute'
```

I think we should not `gsub` on `nil` value.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tmm1/test-queue/19)
<!-- Reviewable:end -->
