### PR TITLE
RSpec 3.2 Fix

### DIFF
--- a/Gemfile-rspec3-0
+++ b/Gemfile-rspec3-0
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gemspec
+gem 'rspec', '~> 3.0.0'

--- a/Gemfile-rspec3-0.lock
+++ b/Gemfile-rspec3-0.lock
@@ -1,0 +1,40 @@
+PATH
+  remote: .
+  specs:
+    test-queue (0.2.12)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    cucumber (1.3.19)
+      builder (>= 2.1.2)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    diff-lcs (1.2.5)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    multi_json (1.11.0)
+    multi_test (0.1.2)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cucumber (~> 1.3.10)
+  rspec (~> 3.0.0)
+  test-queue!

--- a/Gemfile-rspec3-1
+++ b/Gemfile-rspec3-1
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gemspec
+gem 'rspec', '~> 3.1.0'

--- a/Gemfile-rspec3-1.lock
+++ b/Gemfile-rspec3-1.lock
@@ -1,0 +1,40 @@
+PATH
+  remote: .
+  specs:
+    test-queue (0.2.12)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    cucumber (1.3.19)
+      builder (>= 2.1.2)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    diff-lcs (1.2.5)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    multi_json (1.11.0)
+    multi_test (0.1.2)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cucumber (~> 1.3.10)
+  rspec (~> 3.1.0)
+  test-queue!

--- a/Gemfile-rspec3-2
+++ b/Gemfile-rspec3-2
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gemspec
+gem 'rspec', '~> 3.2.0'

--- a/Gemfile-rspec3-2.lock
+++ b/Gemfile-rspec3-2.lock
@@ -1,0 +1,41 @@
+PATH
+  remote: .
+  specs:
+    test-queue (0.2.12)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    cucumber (1.3.19)
+      builder (>= 2.1.2)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    diff-lcs (1.2.5)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    multi_json (1.11.0)
+    multi_test (0.1.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cucumber (~> 1.3.10)
+  rspec (~> 3.2.0)
+  test-queue!


### PR DESCRIPTION
RSpec 3.2 has [slightly changed how hooks are handled around the suite](https://github.com/rspec/rspec-core/commit/8232f61e0ba17b71dfd426eaf07da48ee2cad47e), and this has broken the test queue rspec runner:

```
$ for gemfile in Gemfile-rspec3-?; do echo $gemfile; BUNDLE_GEMFILE="$gemfile" bundle exec rspec-queue test/sample_spec.rb; done
Gemfile-rspec3-0
Starting test-queue master (/tmp/test_queue_95888_70258872569000.sock)

==> Starting test-queue worker [1] (96073 on Bumblebee.local) - iterating over /tmp/test_queue_95888_70258872569000.sock

    RSpecSleep(1): .  <0.260>
    RSpecSleep(4): .  <0.251>
    RSpecSleep(25): .  <0.252>
    RSpecSleep(5): .  <0.251>
    RSpecSleep(15): .  <0.251>
    RSpecSleep(26): .  <0.251>
    RSpecSleep(7): .  <0.252>
    RSpecFailure: F  <0.007>


Failures:

  1) RSpecFailure fails
     Failure/Error: expect(:foo).to eq :bar

       expected: :bar
            got: :foo

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -:bar
       +:foo
     # ./test/sample_spec.rb:21:in `block (2 levels) in <top (required)>'
     # ./lib/test_queue/runner/rspec3.rb:22:in `block (2 levels) in run_specs'
     # ./lib/test_queue/iterator.rb:36:in `block in each'
     # ./lib/test_queue/runner.rb:261:in `around_filter'
     # ./lib/test_queue/iterator.rb:36:in `call'
     # ./lib/test_queue/iterator.rb:36:in `each'
     # ./lib/test_queue/runner/rspec3.rb:19:in `map'
     # ./lib/test_queue/runner/rspec3.rb:19:in `block in run_specs'
     # ./lib/test_queue/runner/rspec3.rb:14:in `run_specs'
     # ./lib/test_queue/runner/rspec.rb:22:in `run_worker'
     # ./lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
     # ./lib/test_queue/runner.rb:223:in `fork'
     # ./lib/test_queue/runner.rb:223:in `block in spawn_workers'
     # ./lib/test_queue/runner.rb:220:in `times'
     # ./lib/test_queue/runner.rb:220:in `spawn_workers'
     # ./lib/test_queue/runner.rb:160:in `execute_parallel'
     # ./lib/test_queue/runner.rb:94:in `execute'

Finished in 1.83 seconds (files took 0.65974 seconds to load)
8 examples, 1 failure

Failed examples:

rspec ./test/sample_spec.rb:20 # RSpecFailure fails

==> Summary (4 workers in 2.1099s)

    [ 4]                                       8 examples, 0 failures         8 suites in 1.7920s      (pid 96076 exit 0)
    [ 1]                                        8 examples, 1 failure         8 suites in 1.8613s      (pid 96073 exit 1)
    [ 3]                                       8 examples, 0 failures         8 suites in 2.0587s      (pid 96075 exit 0)
    [ 2]                                       8 examples, 0 failures         8 suites in 2.0645s      (pid 96074 exit 0)

==> Failures

  1) RSpecFailure fails
     Failure/Error: expect(:foo).to eq :bar

       expected: :bar
            got: :foo

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -:bar
       +:foo
     # ./test/sample_spec.rb:21:in `block (2 levels) in <top (required)>'
     # ./lib/test_queue/runner/rspec3.rb:22:in `block (2 levels) in run_specs'
     # ./lib/test_queue/iterator.rb:36:in `block in each'
     # ./lib/test_queue/runner.rb:261:in `around_filter'
     # ./lib/test_queue/iterator.rb:36:in `call'
     # ./lib/test_queue/iterator.rb:36:in `each'
     # ./lib/test_queue/runner/rspec3.rb:19:in `map'
     # ./lib/test_queue/runner/rspec3.rb:19:in `block in run_specs'
     # ./lib/test_queue/runner/rspec3.rb:14:in `run_specs'
     # ./lib/test_queue/runner/rspec.rb:22:in `run_worker'
     # ./lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
     # ./lib/test_queue/runner.rb:223:in `fork'
     # ./lib/test_queue/runner.rb:223:in `block in spawn_workers'
     # ./lib/test_queue/runner.rb:220:in `times'
     # ./lib/test_queue/runner.rb:220:in `spawn_workers'
     # ./lib/test_queue/runner.rb:160:in `execute_parallel'
     # ./lib/test_queue/runner.rb:94:in `execute'

Gemfile-rspec3-1
Starting test-queue master (/tmp/test_queue_96078_70202494111940.sock)

==> Starting test-queue worker [4] (96269 on Bumblebee.local) - iterating over /tmp/test_queue_96078_70202494111940.sock

    RSpecSleep(1): .  <0.257>
    RSpecSleep(8): .  <0.251>
    RSpecSleep(18): .  <0.252>
    RSpecSleep(7): .  <0.253>
    RSpecSleep(12): .  <0.253>
    RSpecSleep(26): .  <0.251>
    RSpecSleep(11): .  <0.252>
    RSpecFailure: F  <0.013>


Failures:

  1) RSpecFailure fails
     Failure/Error: expect(:foo).to eq :bar

       expected: :bar
            got: :foo

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -:bar
       +:foo
     # ./test/sample_spec.rb:21:in `block (2 levels) in <top (required)>'
     # ./lib/test_queue/runner/rspec3.rb:22:in `block (2 levels) in run_specs'
     # ./lib/test_queue/iterator.rb:36:in `block in each'
     # ./lib/test_queue/runner.rb:261:in `around_filter'
     # ./lib/test_queue/iterator.rb:36:in `call'
     # ./lib/test_queue/iterator.rb:36:in `each'
     # ./lib/test_queue/runner/rspec3.rb:19:in `map'
     # ./lib/test_queue/runner/rspec3.rb:19:in `block in run_specs'
     # ./lib/test_queue/runner/rspec3.rb:14:in `run_specs'
     # ./lib/test_queue/runner/rspec.rb:22:in `run_worker'
     # ./lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
     # ./lib/test_queue/runner.rb:223:in `fork'
     # ./lib/test_queue/runner.rb:223:in `block in spawn_workers'
     # ./lib/test_queue/runner.rb:220:in `times'
     # ./lib/test_queue/runner.rb:220:in `spawn_workers'
     # ./lib/test_queue/runner.rb:160:in `execute_parallel'
     # ./lib/test_queue/runner.rb:94:in `execute'

Finished in 1.8 seconds (files took 0.7578 seconds to load)
8 examples, 1 failure

Failed examples:

rspec ./test/sample_spec.rb:20 # RSpecFailure fails

==> Summary (4 workers in 2.1010s)

    [ 2]                                       8 examples, 0 failures         8 suites in 1.8438s      (pid 96267 exit 0)
    [ 4]                                        8 examples, 1 failure         8 suites in 1.8398s      (pid 96269 exit 1)
    [ 1]                                       8 examples, 0 failures         8 suites in 2.0925s      (pid 96266 exit 0)
    [ 3]                                       8 examples, 0 failures         8 suites in 2.0878s      (pid 96268 exit 0)

==> Failures

  1) RSpecFailure fails
     Failure/Error: expect(:foo).to eq :bar

       expected: :bar
            got: :foo

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -:bar
       +:foo
     # ./test/sample_spec.rb:21:in `block (2 levels) in <top (required)>'
     # ./lib/test_queue/runner/rspec3.rb:22:in `block (2 levels) in run_specs'
     # ./lib/test_queue/iterator.rb:36:in `block in each'
     # ./lib/test_queue/runner.rb:261:in `around_filter'
     # ./lib/test_queue/iterator.rb:36:in `call'
     # ./lib/test_queue/iterator.rb:36:in `each'
     # ./lib/test_queue/runner/rspec3.rb:19:in `map'
     # ./lib/test_queue/runner/rspec3.rb:19:in `block in run_specs'
     # ./lib/test_queue/runner/rspec3.rb:14:in `run_specs'
     # ./lib/test_queue/runner/rspec.rb:22:in `run_worker'
     # ./lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
     # ./lib/test_queue/runner.rb:223:in `fork'
     # ./lib/test_queue/runner.rb:223:in `block in spawn_workers'
     # ./lib/test_queue/runner.rb:220:in `times'
     # ./lib/test_queue/runner.rb:220:in `spawn_workers'
     # ./lib/test_queue/runner.rb:160:in `execute_parallel'
     # ./lib/test_queue/runner.rb:94:in `execute'

Gemfile-rspec3-2
Starting test-queue master (/tmp/test_queue_96270_70212967767100.sock)

==> Starting test-queue worker [4] (96457 on Bumblebee.local) - iterating over /tmp/test_queue_96270_70212967767100.sock



Finished in 0.0012 seconds (files took 0.4332 seconds to load)
0 examples, 0 failures

/Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:622:in `owner_parent_groups': undefined method `parent_groups' for #<RSpec::Core::Configuration:0x007fb7757a8b70> (NoMethodError)
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:602:in `run_example_hooks_for'
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:473:in `run'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:29:in `ensure in block in run_specs'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:29:in `block in run_specs'
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/reporter.rb:62:in `report'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:14:in `run_specs'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec.rb:22:in `run_worker'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:223:in `fork'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:223:in `block in spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:220:in `times'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:220:in `spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:160:in `execute_parallel'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:94:in `execute'
	from /Users/sj26/Projects/test-queue/bin/rspec-queue:4:in `<top (required)>'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `load'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `<main>'

==> Starting test-queue worker [3] (96456 on Bumblebee.local) - iterating over /tmp/test_queue_96270_70212967767100.sock



Finished in 0.00187 seconds (files took 0.43463 seconds to load)
0 examples, 0 failures

/Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:622:in `owner_parent_groups': undefined method `parent_groups' for #<RSpec::Core::Configuration:0x007fb7757a8b70> (NoMethodError)
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:602:in `run_example_hooks_for'
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:473:in `run'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:29:in `ensure in block in run_specs'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:29:in `block in run_specs'
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/reporter.rb:62:in `report'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:14:in `run_specs'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec.rb:22:in `run_worker'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:223:in `fork'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:223:in `block in spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:220:in `times'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:220:in `spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:160:in `execute_parallel'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:94:in `execute'
	from /Users/sj26/Projects/test-queue/bin/rspec-queue:4:in `<top (required)>'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `load'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `<main>'

==> Starting test-queue worker [2] (96455 on Bumblebee.local) - iterating over /tmp/test_queue_96270_70212967767100.sock



Finished in 0.00131 seconds (files took 0.39137 seconds to load)
0 examples, 0 failures

/Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:622:in `owner_parent_groups': undefined method `parent_groups' for #<RSpec::Core::Configuration:0x007fb7757a8b70> (NoMethodError)
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:602:in `run_example_hooks_for'
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:473:in `run'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:29:in `ensure in block in run_specs'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:29:in `block in run_specs'
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/reporter.rb:62:in `report'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:14:in `run_specs'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec.rb:22:in `run_worker'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:223:in `fork'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:223:in `block in spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:220:in `times'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:220:in `spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:160:in `execute_parallel'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:94:in `execute'
	from /Users/sj26/Projects/test-queue/bin/rspec-queue:4:in `<top (required)>'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `load'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `<main>'

==> Starting test-queue worker [1] (96454 on Bumblebee.local) - iterating over /tmp/test_queue_96270_70212967767100.sock



Finished in 0.00123 seconds (files took 0.39145 seconds to load)
0 examples, 0 failures

/Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:622:in `owner_parent_groups': undefined method `parent_groups' for #<RSpec::Core::Configuration:0x007fb7757a8b70> (NoMethodError)
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:602:in `run_example_hooks_for'
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/hooks.rb:473:in `run'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:29:in `ensure in block in run_specs'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:29:in `block in run_specs'
	from /Users/sj26/.rbenv/gems/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/reporter.rb:62:in `report'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec3.rb:14:in `run_specs'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner/rspec.rb:22:in `run_worker'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:223:in `fork'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:223:in `block in spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:220:in `times'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:220:in `spawn_workers'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:160:in `execute_parallel'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:94:in `execute'
	from /Users/sj26/Projects/test-queue/bin/rspec-queue:4:in `<top (required)>'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `load'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `<main>'
^C
/Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:319:in `select': Interrupt
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:319:in `distribute_queue'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:161:in `execute_parallel'
	from /Users/sj26/Projects/test-queue/lib/test_queue/runner.rb:94:in `execute'
	from /Users/sj26/Projects/test-queue/bin/rspec-queue:4:in `<top (required)>'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `load'
	from /Users/sj26/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rspec-queue:23:in `<main>'
```

After this patch:

```
$ BUNDLE_GEMFILE=Gemfile-rspec3-2 bundle exec rspec-queue test/sample_spec.rb

Starting test-queue master (/tmp/test_queue_96992_70200416915440.sock)

==> Starting test-queue worker [2] (97180 on Bumblebee.local) - iterating over /tmp/test_queue_96992_70200416915440.sock

    RSpecSleep(2): .  <0.259>
    RSpecSleep(29): .  <0.252>
    RSpecSleep(19): .  <0.251>
    RSpecSleep(24): .  <0.252>
    RSpecSleep(27): .  <0.251>
    RSpecSleep(28): .  <0.252>
    RSpecSleep(4): .  <0.251>
    RSpecFailure: F  <0.008>


Failures:

  1) RSpecFailure fails
     Failure/Error: expect(:foo).to eq :bar

       expected: :bar
            got: :foo

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -:bar
       +:foo
     # ./test/sample_spec.rb:21:in `block (2 levels) in <top (required)>'
     # ./lib/test_queue/runner/rspec3.rb:21:in `block (3 levels) in run_specs'
     # ./lib/test_queue/iterator.rb:36:in `block in each'
     # ./lib/test_queue/runner.rb:261:in `around_filter'
     # ./lib/test_queue/iterator.rb:36:in `call'
     # ./lib/test_queue/iterator.rb:36:in `each'
     # ./lib/test_queue/runner/rspec3.rb:18:in `map'
     # ./lib/test_queue/runner/rspec3.rb:18:in `block (2 levels) in run_specs'
     # ./lib/test_queue/runner/rspec3.rb:17:in `block in run_specs'
     # ./lib/test_queue/runner/rspec3.rb:16:in `run_specs'
     # ./lib/test_queue/runner/rspec.rb:22:in `run_worker'
     # ./lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
     # ./lib/test_queue/runner.rb:223:in `fork'
     # ./lib/test_queue/runner.rb:223:in `block in spawn_workers'
     # ./lib/test_queue/runner.rb:220:in `times'
     # ./lib/test_queue/runner.rb:220:in `spawn_workers'
     # ./lib/test_queue/runner.rb:160:in `execute_parallel'
     # ./lib/test_queue/runner.rb:94:in `execute'

Finished in 1.8 seconds (files took 0.67859 seconds to load)
8 examples, 1 failure

Failed examples:

rspec ./test/sample_spec.rb:20 # RSpecFailure fails


==> Summary (4 workers in 2.0939s)

    [ 4]                                       8 examples, 0 failures         8 suites in 1.7918s      (pid 97182 exit 0)
    [ 2]                                        8 examples, 1 failure         8 suites in 1.8524s      (pid 97180 exit 1)
    [ 1]                                       8 examples, 0 failures         8 suites in 2.0849s      (pid 97179 exit 0)
    [ 3]                                       8 examples, 0 failures         8 suites in 2.0586s      (pid 97181 exit 0)

==> Failures

  1) RSpecFailure fails
     Failure/Error: expect(:foo).to eq :bar

       expected: :bar
            got: :foo

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -:bar
       +:foo
     # ./test/sample_spec.rb:21:in `block (2 levels) in <top (required)>'
     # ./lib/test_queue/runner/rspec3.rb:21:in `block (3 levels) in run_specs'
     # ./lib/test_queue/iterator.rb:36:in `block in each'
     # ./lib/test_queue/runner.rb:261:in `around_filter'
     # ./lib/test_queue/iterator.rb:36:in `call'
     # ./lib/test_queue/iterator.rb:36:in `each'
     # ./lib/test_queue/runner/rspec3.rb:18:in `map'
     # ./lib/test_queue/runner/rspec3.rb:18:in `block (2 levels) in run_specs'
     # ./lib/test_queue/runner/rspec3.rb:17:in `block in run_specs'
     # ./lib/test_queue/runner/rspec3.rb:16:in `run_specs'
     # ./lib/test_queue/runner/rspec.rb:22:in `run_worker'
     # ./lib/test_queue/runner.rb:228:in `block (2 levels) in spawn_workers'
     # ./lib/test_queue/runner.rb:223:in `fork'
     # ./lib/test_queue/runner.rb:223:in `block in spawn_workers'
     # ./lib/test_queue/runner.rb:220:in `times'
     # ./lib/test_queue/runner.rb:220:in `spawn_workers'
     # ./lib/test_queue/runner.rb:160:in `execute_parallel'
     # ./lib/test_queue/runner.rb:94:in `execute'
```