### PR TITLE
Make sure the slave message is set

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -193,9 +193,7 @@ module TestQueue
       return unless relay?
 
       sock = connect_to_relay
-      message = " #{@slave_message}" if @slave_message
-      message.gsub!(/(\r|\n)/, "") # Our "protocol" is newline-separated
-      sock.puts("SLAVE #{@concurrency} #{Socket.gethostname} #{@run_token}#{message}")
+      sock.puts("SLAVE #{@concurrency} #{Socket.gethostname} #{@run_token}#{slave_message}")
       response = sock.gets.strip
       unless response == "OK"
         STDERR.puts "*** Got non-OK response from master: #{response}"
@@ -206,6 +204,11 @@ module TestQueue
     rescue Errno::ECONNREFUSED
       STDERR.puts "*** Unable to connect to relay #{@relay}. Aborting.."
       exit! 1
+    end
+
+    def slave_message
+      message = @slave_message ? " #{@slave_message}" : ""
+      message.gsub(/(\r|\n)/, "") # Our "protocol" is newline-separated
     end
 
     def stop_master


### PR DESCRIPTION
I've ran into this today trying to use multiple masters

```
/Users/antonio/github/test-queue/lib/test_queue/runner.rb:197:in `start_relay': undefined method `gsub!' for nil:NilClass (NoMethodError)
        from /Users/antonio/github/test-queue/lib/test_queue/runner.rb:159:in `execute_parallel'
        from /Users/antonio/github/test-queue/lib/test_queue/runner.rb:94:in `execute'
        from /Users/antonio/github/test-queue/bin/minitest-queue:5:in `<top (required)>'
        from /Users/antonio/.gem/ruby/2.1.6/bin/minitest-queue:23:in `load'
        from /Users/antonio/.gem/ruby/2.1.6/bin/minitest-queue:23:in `<main>'
```

Making sure that a slave message is always available fixes the issue.