### PR TITLE
Add option to split example groups to individual examples for rspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ the workload and relay results back to a central master.
 - `TEST_QUEUE_RELAY_TIMEOUT`: when using remote workers, the amount of time a worker will try to reconnect to start work
 - `TEST_QUEUE_RELAY_TOKEN`: when using remote workers, this must be the same on both workers and the server for remote workers to run tests.
 - `TEST_QUEUE_SLAVE_MESSAGE`: when using remote workers, set this on a slave worker and it will appear on the slave's connection message on the master.
+- `TEST_QUEUE_SPLIT_GROUPS`: split tests up by example rather than example group. Faster for tests with short setup time such as selenium. RSpec only. Add the :no_split tag to ExampleGroups you don't want split.
 
 ### usage
 

--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -37,7 +37,8 @@ module TestQueue
           else
             yield suite
           end
-          @stats[suite.to_s] = Time.now - start
+          key = suite.respond_to?(:id) ? suite.id : suite.to_s
+          @stats[key] = Time.now - start
         else
           break
         end

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -35,8 +35,11 @@ module TestQueue
       end
 
       @procline = $0
-      @queue = queue
-      @suites = queue.inject(Hash.new){ |hash, suite| hash.update suite.to_s => suite }
+      @suites = queue.inject(Hash.new) do |hash, suite|
+        key = suite.respond_to?(:id) ? suite.id : suite.to_s
+        hash.update key => suite
+      end
+      @queue = @suites.keys
 
       @workers = {}
       @completed = []

--- a/lib/test_queue/runner/rspec3.rb
+++ b/lib/test_queue/runner/rspec3.rb
@@ -29,8 +29,16 @@ module RSpec::Core
       @configuration.reporter.report(@world.ordered_example_groups.count) do |reporter|
         @configuration.with_suite_hooks do
           iterator.map { |g|
-            print "    #{g.description}: "
             start = Time.now
+            if g.is_a? ::RSpec::Core::Example
+              print "    #{g.full_description}: "
+              example = g
+              g = example.example_group
+              ::RSpec.world.filtered_examples.clear
+              ::RSpec.world.filtered_examples[g] = [example]
+            else
+              print "    #{g.description}: "
+            end
             ret = g.run(reporter)
             diff = Time.now-start
             puts("  <%.3f>" % diff)


### PR DESCRIPTION
Add SPLIT_GROUPS env option for rspec tests to split example groups to run individual examples off of the queue.