### PR TITLE
Better RSpec parallelization, fixes #25

### DIFF
--- a/Gemfile-rspec3-0.lock
+++ b/Gemfile-rspec3-0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    test-queue (0.2.12)
+    test-queue (0.2.13)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile-rspec3-1.lock
+++ b/Gemfile-rspec3-1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    test-queue (0.2.12)
+    test-queue (0.2.13)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile-rspec3-2.lock
+++ b/Gemfile-rspec3-2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    test-queue (0.2.12)
+    test-queue (0.2.13)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ the workload and relay results back to a central master.
 - `TEST_QUEUE_RELAY_TIMEOUT`: when using remote workers, the amount of time a worker will try to reconnect to start work
 - `TEST_QUEUE_RELAY_TOKEN`: when using remote workers, this must be the same on both workers and the server for remote workers to run tests.
 - `TEST_QUEUE_SLAVE_MESSAGE`: when using remote workers, set this on a slave worker and it will appear on the slave's connection message on the master.
+- `TEST_QUEUE_SPLIT_GROUPS`: divide and conquer the last example group(s) so that all workers finish around the same time. Ideal for massive spec files, and performs well even with slow/expensive context-level hooks. Add the `:no_split` tag to groups you don't want split. RSpec only.
 
 ### usage
 

--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -15,19 +15,25 @@ module TestQueue
       end
     end
 
+    def query(payload)
+      client = connect_to_master(payload)
+      return if client.nil?
+      _r, _w, e = IO.select([client], nil, [client], nil)
+      return if !e.empty?
+
+      if data = client.read(65536)
+        client.close
+        item = Marshal.load(data)
+        return if item.nil? || item.empty?
+        item
+      end
+    end
+
     def each
       fail "already used this iterator. previous caller: #@done" if @done
 
       while true
-        client = connect_to_master('POP')
-        break if client.nil?
-        r, w, e = IO.select([client], nil, [client], nil)
-        break if !e.empty?
-
-        if data = client.read(65536)
-          client.close
-          item = Marshal.load(data)
-          break if item.nil? || item.empty?
+        if item = query('POP')
           suite = @suites[item]
 
           $0 = "#{@procline} - #{suite.respond_to?(:description) ? suite.description : suite}"

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -11,25 +11,130 @@ else
 end
 
 module TestQueue
+  class << self
+    # give ExampleGroups 'n such a quick/easy way to get at this worker's
+    # iterator
+    attr_accessor :iterator
+  end
+
   class Runner
     class RSpec < Runner
+      SPLIT_GROUPS = ["1", "true"].include?(ENV.fetch("TEST_QUEUE_SPLIT_GROUPS", "0").downcase)
+
       def initialize
         @rspec = ::RSpec::Core::QueueRunner.new
         super(@rspec.example_groups.sort_by{ |s| -(stats[s.to_s] || 0) })
+
+        if SPLIT_GROUPS
+          @group_queues = {}
+          @all_groups = {}
+          @queue.each do |group|
+            group.descendants.each do |subgroup|
+              @group_queues[subgroup.to_s] = ::RSpec.world.filtered_examples[subgroup]
+              @all_groups[subgroup.to_s] = subgroup
+            end
+          end
+        end
+      end
+
+      def has_examples_in_queue?(group)
+        @group_queues[group] && @group_queues[group].any?
+      end
+
+      def has_descendant_examples_in_queue?(group)
+        @all_groups[group].descendants.any? { |group| has_examples_in_queue?(group.to_s) }
       end
 
       def run_worker(iterator)
+        ::TestQueue.iterator = iterator
         @rspec.run_each(iterator).to_i
+      end
+
+      # since groups can span runners, we save off the old stats,
+      # figure out our new stats across all runners, and merge
+      # into the old stats
+      def summarize_internal
+        @previous_stats = stats
+        @stats = {}
+        super
+      end
+
+      def save_stats
+        @stats = @previous_stats.merge(stats)
+        super
       end
 
       def summarize_worker(worker)
         worker.stats.each do |s, val|
-          stats[s] = val
+          stats[s] ||= 0
+          stats[s] += val
         end
 
         worker.summary  = worker.lines.grep(/ examples?, /).first
         worker.failure_output = worker.output[/^Failures:\n\n(.*)\n^Finished/m, 1]
       end
+
+      if SPLIT_GROUPS
+        def queue_empty?
+          # suite queue can empty out while the very last examples are
+          # being worked on; wait till they are done so we don't abandon
+          # any live workers
+          super && @group_queues.all? { |key, queue| queue.empty? }
+        end
+
+        def pop_next
+          while item = @queue.shift
+            # might have been finished by another worker, so just discard
+            # it if it has no more examples
+            return item if has_descendant_examples_in_queue?(item.to_s)
+          end
+        end
+
+        def handle_command(cmd, sock)
+          case cmd
+          when /^HAS EXAMPLES (\d+)/
+            data = sock.read($1.to_i)
+            group = Marshal.load(data)
+            sock.write Marshal.dump(has_descendant_examples_in_queue?(group))
+          when /^POP OWN EXAMPLE (\d+)/
+            data = sock.read($1.to_i)
+            group = Marshal.load(data)
+            if has_examples_in_queue?(group)
+              example = @group_queues[group].shift
+              sock.write Marshal.dump(example.full_description)
+            end
+          when /^POP/
+            if obj = pop_next
+              data = Marshal.dump(obj.to_s)
+              sock.write(data)
+              # differs from the original in that we immediately put it
+              # right back at the end of the queue, so that anyone who
+              # finishes early can come help
+              @queue << obj unless obj.metadata[:no_split]
+            end
+          else
+            super
+          end
+        end
+      end
+
+      def iterator_factory(*args)
+        Iterator.new(*args)
+      end
+
+      class Iterator < ::TestQueue::Iterator
+        def has_descendant_examples_in_queue?(group)
+          group = Marshal.dump(group)
+          query("HAS EXAMPLES #{group.bytesize}\n#{group}")
+        end
+
+        def pop_example(group)
+          group = Marshal.dump(group)
+          query("POP OWN EXAMPLE #{group.bytesize}\n#{group}")
+        end
+      end
     end
   end
 end
+
+require_relative 'rspec/split_groups' if TestQueue::Runner::RSpec::SPLIT_GROUPS

--- a/lib/test_queue/runner/rspec/split_groups.rb
+++ b/lib/test_queue/runner/rspec/split_groups.rb
@@ -1,0 +1,60 @@
+module RSpec::Core
+  class ExampleIterator
+    include Enumerable
+
+    def initialize(group, iterator, examples)
+      @iterator = iterator
+      @group = group
+      @examples = Hash[examples.map { |example| [example.full_description, example ]}]
+    end
+
+    def each
+      while true
+        key = @iterator.pop_example(@group.to_s) or break
+        yield @examples[key]
+      end
+      self
+    end
+
+    def ordered
+      self
+    end
+
+    def size
+      @examples.size
+    end
+  end
+
+  class NoOpOrderer
+    def order(items)
+      items
+    end
+  end
+
+  class ExampleGroup
+    # rspec only uses this to determine if before/after :all hooks should
+    # run.
+    #
+    # NOTE: there's a race condition where the last example could be
+    # claimed by someone else after we call this, meaning we might do a
+    # little bit of unnecessary work, but ¯\_(ツ)_/¯
+    def self.descendant_filtered_examples
+      @descendant_filtered_examples ||= TestQueue.iterator.has_descendant_examples_in_queue?(self.to_s) ? [1] : []
+    end
+
+    # make sure rspec gets the examples from the iterator...
+    #
+    # rspec2 does `filtered_examples.ordered.map`
+    # rspec3 does `ordering_strategy.order(filtered_examples).map`
+
+    def self.filtered_examples
+      ExampleIterator.new(self, TestQueue.iterator, RSpec.world.filtered_examples[self])
+    end
+
+    # don't try to sort, since it's an iterator
+    def self.ordering_strategy
+      NoOpOrderer.new
+    end
+  end
+end
+

--- a/test.sh
+++ b/test.sh
@@ -12,12 +12,28 @@ bundle install
 bundle exec minitest-queue ./test/*_minitest4.rb
 bundle exec minitest-queue ./test/*_minispec.rb
 
+export BUNDLE_GEMFILE=Gemfile-rspec3-0
+bundle install
+bundle exec rspec-queue test/sample_spec.rb
+TEST_QUEUE_WORKERS=3 TEST_QUEUE_SPLIT_GROUPS=1 bundle exec rspec-queue test/sample_split_groups_spec.rb
+
+export BUNDLE_GEMFILE=Gemfile-rspec3-1
+bundle install
+bundle exec rspec-queue test/sample_spec.rb
+TEST_QUEUE_WORKERS=3 TEST_QUEUE_SPLIT_GROUPS=1 bundle exec rspec-queue test/sample_split_groups_spec.rb
+
+export BUNDLE_GEMFILE=Gemfile-rspec3-2
+bundle install
+bundle exec rspec-queue test/sample_spec.rb
+TEST_QUEUE_WORKERS=3 TEST_QUEUE_SPLIT_GROUPS=1 bundle exec rspec-queue test/sample_split_groups_spec.rb
+
 export BUNDLE_GEMFILE=Gemfile
 bundle install
 bundle exec minitest-queue ./test/*_minitest4.rb
 bundle exec minitest-queue ./test/*_minitest5.rb
 bundle exec minitest-queue ./test/*_minispec.rb
-bundle exec rspec-queue test
+bundle exec rspec-queue test/sample_spec.rb
+TEST_QUEUE_WORKERS=3 TEST_QUEUE_SPLIT_GROUPS=1 bundle exec rspec-queue test/sample_split_groups_spec.rb
 bundle exec cucumber-queue
 
 TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MiniTestSleep21,MiniTestSleep8,MiniTestFailure" bundle exec minitest-queue ./test/*_minitest5.rb

--- a/test/sample_split_groups_spec.rb
+++ b/test/sample_split_groups_spec.rb
@@ -1,0 +1,49 @@
+require 'rspec'
+
+# given 3 workers, 2 will finish at almost exactly the same time when
+# using TEST_QUEUE_SPLIT_GROUPS=1; 1 worker will run a bit longer due to
+# the no_split tag
+
+describe "MediumSlowGroup" do
+  5.times do |i|
+    it "test #{i}" do
+      sleep(0.25)
+      expect(1).to eq 1
+    end
+  end
+end
+
+describe "BigSlowGroup" do
+  group_run_count = 0
+  before :all do
+    sleep(1)
+    group_run_count += 1
+    # should never run more than once per worker
+    expect(group_run_count).to eq 1
+  end
+
+  20.times do |i|
+    it "test #{i}" do
+      sleep(0.25)
+      expect(1).to eq 1
+    end
+  end
+
+  describe "NestedSlowGroup" do
+    10.times do |i|
+      it "test #{i}" do
+        sleep(0.25)
+        expect(1).to eq 1
+      end
+    end
+  end
+end
+
+describe "NoSplitGroup", no_split: true do
+  30.times do |i|
+    it "test #{i}" do
+      sleep(0.25)
+      expect(1).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Once all groups have been assigned and a worker needs something to do, have it start running examples from one of the as-yet-unfinished groups. This way even if the last group is relatively large, the workers will divide and conquer, finishing around the same time. Hooks into ExampleGroup and friends and uses per-group example queues.

Unlike #26, we don't incur extra overhead from context-level hooks running on each example; they still just run once for each group. Performance overhead from the per-group example queues is negligible; sample_spec.rb's runtime is essentially unchanged. It might be worth making this the default behavior for RSpec once it's battle tested?

#### Other Notes

In order to isolate this to to the rspec* files, I had to do a little bit of refactoring/shuffling (primarily in the first commit). Open to suggestions if anything here seems too crazy :)

Stats are correctly aggregated when groups are split across runners, although they are fairly irrelevant now that we divide up the last groups.

This commit also updates test.sh to get rspec3*, and adds a separate spec file demonstrating the split groups performance.

/cc @bootstraponline @sbonebrake
