### PR TITLE
⚠️ assigned but unused variable

### DIFF
--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -21,7 +21,7 @@ module TestQueue
       while true
         client = connect_to_master('POP')
         break if client.nil?
-        r, w, e = IO.select([client], nil, [client], nil)
+        _r, _w, e = IO.select([client], nil, [client], nil)
         break if !e.empty?
 
         if data = client.read(65536)


### PR DESCRIPTION
This patch fixes a Ruby warning "assigned but unused variable".