### PR TITLE
Allow aborting if too few remote workers connect to the central master

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ the workload and relay results back to a central master.
 - `TEST_QUEUE_RELAY_TIMEOUT`: when using remote workers, the amount of time a worker will try to reconnect to start work
 - `TEST_QUEUE_RELAY_TOKEN`: when using remote workers, this must be the same on both workers and the server for remote workers to run tests.
 - `TEST_QUEUE_SLAVE_MESSAGE`: when using remote workers, set this on a slave worker and it will appear on the slave's connection message on the master.
+- `TEST_QUEUE_REMOTE_WORKER_QUORUM`: when using remote workers, this specifies how many remote workers constitute a quorum.
+- `TEST_QUEUE_REMOTE_WORKER_QUORUM_TIMEOUT`: when using remote workers, if a quorum is not reached after this number of seconds, the build is aborted.
 
 ### usage
 

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -167,10 +167,6 @@ module TestQueue
       stop_master
 
       kill_workers
-
-      until @workers.empty?
-        reap_worker
-      end
     end
 
     def start_master
@@ -292,6 +288,10 @@ module TestQueue
       @workers.each do |pid, worker|
         Process.kill 'KILL', pid
       end
+
+      until @workers.empty?
+        reap_worker
+      end
     end
 
     def reap_worker(blocking=true)
@@ -409,9 +409,6 @@ module TestQueue
     def abort(message)
       @aborting = true
       kill_workers
-      until @workers.empty?
-        reap_worker
-      end
       Kernel::abort("Aborting: #{message}")
     end
 

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -373,7 +373,12 @@ module TestQueue
     end
 
     def check_quorum(remote_workers)
+      # If a subclass decides to allow the build to proceed without a quorum we
+      # should only call #quorum_failed once.
+      return if @quorum_failed
+
       return unless quorum_failed?(remote_workers)
+      @qourum_failed = true
       quorum_failed(remote_workers)
     end
 

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -316,15 +316,13 @@ module TestQueue
 
     def distribute_queue
       return if relay?
-      quorum_members = 0
       remote_workers = 0
 
       until @queue.empty? && remote_workers == 0
-        if @remote_worker_quorum &&
-          quorum_members < @remote_worker_quorum &&
-          @remote_worker_quorum_timeout &&
-          @remote_worker_quorum_timeout <= Time.now - @start_time
-          STDERR.puts "After #{@remote_worker_quorum_timeout}s #{quorum_members} remote workers had connected, which is less than the #{@remote_worker_quorum} required for a quorum. Aborting."
+        if @queue.any? &&
+          @remote_worker_quorum && remote_workers < @remote_worker_quorum &&
+          @remote_worker_quorum_timeout && @remote_worker_quorum_timeout <= Time.now - @start_time
+          STDERR.puts "After #{@remote_worker_quorum_timeout}s #{remote_workers} remote workers are connected, which is less than the #{@remote_worker_quorum} required for a quorum. Aborting."
           break
         end
 
@@ -349,7 +347,6 @@ module TestQueue
               # If we have a slave from a different test run, don't respond, and it will consider the test run done.
               sock.write("OK\n")
               remote_workers += num
-              quorum_members += num
             else
               STDERR.puts "*** Worker from run #{run_token} connected to master for run #{@run_token}; ignoring."
               sock.write("WRONG RUN\n")


### PR DESCRIPTION
Launching remote workers can be unreliable. Builds take far longer than usual when too few remote workers get launched. The new `TEST_QUEUE_REMOTE_WORKER_QUORUM` and `TEST_QUEUE_REMOTE_WORKER_QUORUM_TIMEOUT` environment variables let you specify how many workers must connect within N seconds of the build starting, or else the build will be aborted. This lets builds fail fast when there is some problem with remote workers, rather than the central master trying to chug through all the tests on its own.

/cc @bhuga @tmm1