### PR TITLE
Add TestQueue::Runner#queue_status

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -311,6 +311,8 @@ module TestQueue
       remote_workers = 0
 
       until @queue.empty? && remote_workers == 0
+        queue_status(@start_time, @queue.size, @workers.size, remote_workers)
+
         if IO.select([@server], nil, nil, 0.1).nil?
           reap_worker(false) if @workers.any? # check for worker deaths
         else
@@ -406,6 +408,26 @@ module TestQueue
       @aborting = true
       kill_workers
       Kernel::abort("Aborting: #{message}")
+    end
+
+    # Subclasses can override to monitor the status of the queue.
+    #
+    # For example, you may want to record metrics about how quickly remote
+    # workers connect, or abort the build if not enough connect.
+    #
+    # This method is called very frequently during the test run, so don't do
+    # anything expensive/blocking.
+    #
+    # This method is not called on remote masters when using remote workers,
+    # only on the central master.
+    #
+    # start_time          - Time when the test run began
+    # queue_size          - Integer number of suites left in the queue
+    # local_worker_count  - Integer number of active local workers
+    # remote_worker_count - Integer number of active remote workers
+    #
+    # Returns nothing.
+    def queue_status(start_time, queue_size, local_worker_count, remote_worker_count)
     end
   end
 end


### PR DESCRIPTION
This method is called on each iteration of the queue loop. Subclasses can override to add whatever behavior they need. For instance, you could record metrics about how many remote workers have connected. Or you could abort the build if not enough workers connect.

I also added an `abort` method to let subclasses cleanly abort a test run.

This replaces #33; subclasses can implement that behavior using this new callback if they choose.

/cc @bhuga @tmm1