### PR TITLE
Use `exit` instead of `exit!` to kill master

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -137,7 +137,7 @@ module TestQueue
 
       estatus = @completed.inject(0){ |s, worker| s + worker.status.exitstatus }
       estatus = 255 if estatus > 255
-      exit!(estatus)
+      exit(estatus)
     end
 
     def summarize


### PR DESCRIPTION
So it plays nicely with `at_exit` (especially of `simplecov`).

While finishing forked processes with `exit!` is a safe
idea (to ensure killing child processes), master process doesn't really
needs to be forcely killed.

refs #35 
