### PR TITLE
Enable fast failures

### DIFF
--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -13,13 +13,22 @@ module TestQueue
         @tcp_address = $1
         @tcp_port = $2.to_i
       end
+      @failures = 0
     end
 
     def each
       fail "already used this iterator. previous caller: #@done" if @done
 
       while true
-        client = connect_to_master('POP')
+        # If we've hit too many failures in one worker, assume the entire
+        # test suite is broken, and notify master so the run
+        # can be immediately halted.
+        if ENV["TEST_QUEUE_EARLY_FAILURE_LIMIT"] && @failures >= ENV["TEST_QUEUE_EARLY_FAILURE_LIMIT"].to_i
+          connect_to_master("KABOOM")
+          break
+        else
+          client = connect_to_master('POP')
+        end
         break if client.nil?
         _r, _w, e = IO.select([client], nil, [client], nil)
         break if !e.empty?
@@ -39,6 +48,7 @@ module TestQueue
           end
           key = suite.respond_to?(:id) ? suite.id : suite.to_s
           @stats[key] = Time.now - start
+          @failures += suite.failure_count if suite.respond_to? :failure_count
         else
           break
         end

--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -2,7 +2,7 @@ module TestQueue
   class Iterator
     attr_reader :stats, :sock
 
-    def initialize(sock, suites, filter=nil)
+    def initialize(sock, suites, filter=nil, early_failure_limit: nil)
       @done = false
       @stats = {}
       @procline = $0
@@ -14,6 +14,7 @@ module TestQueue
         @tcp_port = $2.to_i
       end
       @failures = 0
+      @early_failure_limit = early_failure_limit
     end
 
     def each
@@ -23,7 +24,7 @@ module TestQueue
         # If we've hit too many failures in one worker, assume the entire
         # test suite is broken, and notify master so the run
         # can be immediately halted.
-        if ENV["TEST_QUEUE_EARLY_FAILURE_LIMIT"] && @failures >= ENV["TEST_QUEUE_EARLY_FAILURE_LIMIT"].to_i
+        if @early_failure_limit && @failures >= @early_failure_limit
           connect_to_master("KABOOM")
           break
         else

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -360,6 +360,10 @@ module TestQueue
             worker = Marshal.load(data)
             worker_completed(worker)
             remote_workers -= 1
+          when /^KABOOM/
+            # worker reporting an abnormal number of test failures;
+            # stop everything immediately and report the results.
+            break
           end
           sock.close
         end

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -34,6 +34,14 @@ module TestQueue
         queue.sort_by!{ |s| forced.index(s.to_s) }
       end
 
+      if ENV['TEST_QUEUE_EARLY_FAILURE_LIMIT']
+        begin
+          @early_failure_limit = Integer(ENV['TEST_QUEUE_EARLY_FAILURE_LIMIT'])
+        rescue ArgumentError
+          raise ArgumentError, 'TEST_QUEUE_EARLY_FAILURE_LIMIT could not be parsed as an integer'
+        end
+      end
+
       @procline = $0
       @suites = queue.inject(Hash.new) do |hash, suite|
         key = suite.respond_to?(:id) ? suite.id : suite.to_s
@@ -232,7 +240,7 @@ module TestQueue
         pid = fork do
           @server.close if @server
 
-          iterator = Iterator.new(relay?? @relay : @socket, @suites, method(:around_filter))
+          iterator = Iterator.new(relay?? @relay : @socket, @suites, method(:around_filter), early_failure_limit: @early_failure_limit)
           after_fork_internal(num, iterator)
           ret = run_worker(iterator) || 0
           cleanup_worker

--- a/lib/test_queue/runner/minitest4.rb
+++ b/lib/test_queue/runner/minitest4.rb
@@ -46,6 +46,10 @@ class MiniTest::Unit::TestCase
       @@test_suites.keys.reject{ |s| s.test_methods.empty? }
     end
   end
+
+  def failure_count
+    failures.length
+  end
 end
 
 module TestQueue

--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -9,6 +9,12 @@ module MiniTest
     suites.map { |suite| suite.run reporter, options }
   end
 
+  class Runnable
+    def failure_count
+      failures.length
+    end
+  end
+
   class Test
     def self.runnables= runnables
       @@runnables = runnables

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -10,6 +10,12 @@ else
   fail 'requires rspec version 2 or 3'
 end
 
+class ::RSpec::Core::ExampleGroup
+  def self.failure_count
+    examples.map {|e| e.execution_result[:status] == "failed"}.length
+  end
+end
+
 module TestQueue
   class Runner
     class RSpec < Runner

--- a/lib/test_queue/runner/testunit.rb
+++ b/lib/test_queue/runner/testunit.rb
@@ -26,6 +26,10 @@ class Test::Unit::TestSuite
     yield(FINISHED, name)
     yield(FINISHED_OBJECT, self)
   end
+
+  def failure_count
+    (@iterator || @tests).map {|t| t.instance_variable_get(:@_result).failure_count}.inject(0, :+)
+  end
 end
 
 module TestQueue


### PR DESCRIPTION
This allows builds to optionally be halted early if any worker encounters abnormal numbers of test failures.

The number of failures to halt at is defined in the `TEST_QUEUE_EARLY_FAILURE_LIMIT` environment variable; if defined, at the end of each suite, the worker will compare the number of failures it's encountered to date via that number. If it hits the limit, the worker immediately halts itself and notifies master with the new `KABOOM` command; if master encounters `KABOOM`, it stops distributing jobs and reaps all of the workers immediately without waiting for completion, then prints the results.

This can be useful for very large test suites; for example, if a CI system is regularly testing branches which can take multiple minutes to complete, it can be helpful for it to be able to abort early if it looks like every test is going to fail due to environment issues (bad test database, etc.)

I added support for measuring test failures per-suite for minitest, rspec, and Test::Unit, but not cucumber and puppet_lint.

This needs some more testing, but appears to be working fine in `test.sh` calls.

cc @bhuga 