### PR TITLE
Use absolute_path for require in minitest-queue.

### DIFF
--- a/bin/minitest-queue
+++ b/bin/minitest-queue
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 require 'test_queue'
 require 'test_queue/runner/minitest'
-ARGV.each{ |f| require(f) }
+ARGV.each{ |f| require(File.absolute_path(f)) }
 TestQueue::Runner::MiniTest.new.execute

--- a/bin/testunit-queue
+++ b/bin/testunit-queue
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 require 'test_queue'
 require 'test_queue/runner/testunit'
-ARGV.each{ |f| require(f) }
+ARGV.each{ |f| require(File.absolute_path(f)) }
 TestQueue::Runner::TestUnit.new.execute


### PR DESCRIPTION
The README suggests running `minitest-queue` via `minitest-queue $(find test/
-name \*_test.rb)`. This command fails with:

> minitest-queue:4:in `require': cannot load such file -- test//blah_test.rb (LoadError)

The issue is that the argument does not have the relative path specifier `./`
prefixing the filename. The fix passes the absolute_path to the file. This fix
also works if the absolute path is already given.

This commit also fixes the same issue for `testunit-queue`.