### PR TITLE
Support TEST_QUEUE_SPLIT_GROUPS for minitest5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ the workload and relay results back to a central master.
 - `TEST_QUEUE_RELAY_TIMEOUT`: when using remote workers, the amount of time a worker will try to reconnect to start work
 - `TEST_QUEUE_RELAY_TOKEN`: when using remote workers, this must be the same on both workers and the server for remote workers to run tests.
 - `TEST_QUEUE_SLAVE_MESSAGE`: when using remote workers, set this on a slave worker and it will appear on the slave's connection message on the master.
-- `TEST_QUEUE_SPLIT_GROUPS`: split tests up by example rather than example group. Faster for tests with short setup time such as selenium. RSpec only. Add the :no_split tag to ExampleGroups you don't want split.
+- `TEST_QUEUE_SPLIT_GROUPS`: split tests up by example rather than example
+group. Faster for tests with short setup time such as selenium. RSpec and
+minitest5 only. RSpec: Add the :no_split tag to ExampleGroups you don't want
+split.
 
 ### usage
 

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -99,6 +99,10 @@ module TestQueue
         end
     end
 
+    def self.split_groups?
+      ENV['TEST_QUEUE_SPLIT_GROUPS'] && %w(1 true t yes y).include?(ENV['TEST_QUEUE_SPLIT_GROUPS'].strip.downcase)
+    end
+
     # Run the tests.
     #
     # If exit_when_done is true, exit! will be called before this method

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -21,8 +21,7 @@ module TestQueue
     class RSpec < Runner
       def initialize
         @rspec = ::RSpec::Core::QueueRunner.new
-        @split_groups = ENV['TEST_QUEUE_SPLIT_GROUPS'] && ENV['TEST_QUEUE_SPLIT_GROUPS'].strip.downcase == 'true'
-        if @split_groups
+        if self.class.split_groups?
           groups = @rspec.example_groups
           groups_to_split, groups_to_keep = [], []
           groups.each do |group|

--- a/test/samples/sample_minitest5.rb
+++ b/test/samples/sample_minitest5.rb
@@ -10,8 +10,9 @@ end
   Object.const_set("MiniTestSleep#{i}", Class.new(MiniTest::Test) do
     define_method('test_sleep') do
       start = Time.now
-      sleep(0.25)
-      assert_in_delta Time.now-start, 0.25, 0.02
+      sleep_time = 0.01 * i
+      sleep(sleep_time)
+      assert_in_delta Time.now-start, sleep_time, 0.02
     end
   end)
 end


### PR DESCRIPTION
Similar to #26 for minitest5.

This mode is enabled by setting the environment variable
`TEST_QUEUE_SPLIT_GROUPS`.
