### PR TITLE
Extract method for collecting worker result

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -384,20 +384,23 @@ module TestQueue
         worker.status = $?
         worker.end_time = Time.now
 
-        if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_output")
-          worker.output = IO.binread(file)
-          FileUtils.rm(file)
-        end
-
-        if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_suites")
-          worker.suites.replace(Marshal.load(IO.binread(file)))
-          FileUtils.rm(file)
-        end
-
+        collect_worker_data(worker)
         relay_to_master(worker) if relay?
         worker_completed(worker)
 
         true
+      end
+    end
+
+    def collect_worker_data(worker)
+      if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_output")
+        worker.output = IO.binread(file)
+        FileUtils.rm(file)
+      end
+
+      if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_suites")
+        worker.suites.replace(Marshal.load(IO.binread(file)))
+        FileUtils.rm(file)
       end
     end
 


### PR DESCRIPTION
I'm using test-queue with rspec in master-slave distributed mode over several machines. I would like to collect structured data such as test coverage metrics from the worker processes on both the master and the slave machines and summarize them on the master machine to calculate a coverage rate.

I've found that it would be handy to piggyback such miscellaneous data on the `WORKER` messages sent from the slaves to the master. But there is not an appropriate Runner method to override in order to prepare such an additional payload relayed from slaves.

This patch extracts routines related to a master collecting test results from a worker process as a method, in order to allow subclasses of Runner to collect application-specific data.