### PR TITLE
Use Test::Unit::Collector::ObjectSpace instead

### DIFF
--- a/lib/test_queue/runner/testunit.rb
+++ b/lib/test_queue/runner/testunit.rb
@@ -2,7 +2,7 @@ require 'test_queue/runner'
 
 gem 'test-unit'
 require 'test/unit'
-require 'test/unit/collector/descendant'
+require 'test/unit/collector/objectspace'
 require 'test/unit/testresult'
 require 'test/unit/testsuite'
 require 'test/unit/ui/console/testrunner'
@@ -36,7 +36,7 @@ module TestQueue
   class Runner
     class TestUnit < Runner
       def initialize
-        @suite = Test::Unit::Collector::Descendant.new.collect
+        @suite = Test::Unit::Collector::ObjectSpace.new.collect
         tests = @suite.tests.sort_by{ |s| -(stats[s.to_s] || 0) }
         super(tests)
       end


### PR DESCRIPTION
Test::Unit::Collector::Descendant can not be executed in parallel on Rails.

Because, the test suite is only Test::Unit::TestCase of the parent class of ActiveSupport::TestCase.
https://github.com/test-unit/test-unit/blob/3.2.1/lib/test/unit/collector.rb#L36

It is better to use Test::Unit::Collector::ObjectSpace instead.
