### PR TITLE
Remove TEST_QUEUE_WORKERS=0 support

### DIFF
--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -53,3 +53,10 @@ setup() {
   assert_output_contains "1) Failure:"
   assert_output_contains "MiniTestFailure#test_fail"
 }
+
+@test "fails when TEST_QUEUE_WORKERS is <= 0" {
+  export TEST_QUEUE_WORKERS=0
+  run bundle exec minitest-queue ./test/samples/sample_minitest5.rb
+  assert_status 1
+  assert_output_contains "Worker count (0) must be greater than 0"
+}


### PR DESCRIPTION
I don't think this is useful at all for test-queue users. It has some small utility for test-queue developers, but it's pretty easy to debug things with `TEST_QUEUE_WORKERS=1`. This mode is buggy in at least one way: it doesn't set the exit code correctly.

So, this is essentially unused/unnecessary code and could be removed on that basis alone. But it also happens to be making it harder to make another change I'm working on: making the test-queue master not `require` any test files and making the workers only `require` the test files they need, which helps with startup latency in very large test suites.

/cc @tmm1 @bhuga 