### PR TITLE
Only wait for our own workers' PIDs

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -302,23 +302,29 @@ module TestQueue
       worker.failure_output = ''
     end
 
-    def reap_worker(blocking=true)
-      if pid = Process.waitpid(-1, blocking ? 0 : Process::WNOHANG) and worker = @workers.delete(pid)
+    def reap_workers(blocking=true)
+      @workers.delete_if do |_, worker|
+        if Process.waitpid(worker.pid, blocking ? 0 : Process::WNOHANG).nil?
+          next false
+        end
+
         worker.status = $?
         worker.end_time = Time.now
 
-        if File.exists?(file = "/tmp/test_queue_worker_#{pid}_output")
+        if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_output")
           worker.output = IO.binread(file)
           FileUtils.rm(file)
         end
 
-        if File.exists?(file = "/tmp/test_queue_worker_#{pid}_stats")
+        if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_stats")
           worker.stats = Marshal.load(IO.binread(file))
           FileUtils.rm(file)
         end
 
         relay_to_master(worker) if relay?
         worker_completed(worker)
+
+        true
       end
     end
 
@@ -336,7 +342,7 @@ module TestQueue
         queue_status(@start_time, @queue.size, @workers.size, remote_workers)
 
         if IO.select([@server], nil, nil, 0.1).nil?
-          reap_worker(false) if @workers.any? # check for worker deaths
+          reap_workers(false) # check for worker deaths
         else
           sock = @server.accept
           cmd = sock.gets.strip
@@ -378,10 +384,7 @@ module TestQueue
       end
     ensure
       stop_master
-
-      until @workers.empty?
-        reap_worker
-      end
+      reap_workers
     end
 
     def relay?
@@ -420,9 +423,7 @@ module TestQueue
         Process.kill 'KILL', pid
       end
 
-      until @workers.empty?
-        reap_worker
-      end
+      reap_workers
     end
 
     # Stop the test run immediately.


### PR DESCRIPTION
If the code invoking test-queue also forks its own subprocesses, we could steal their termination status via our `Process.waitpid(-1)` call. Now we only listen for termination of our own workers' PIDs.

The change in the structure of the code also means that we call `waitpid` for every worker on every iteration of the `distribute_queue` loop. With 8 workers, this is about 6-7x more expensive in a microbenchmark (1 microsecond for `Process.waitpid(-1)` vs. 7 microseconds for `Process.waitpid(pid)` in a loop), but should still be dwarfed by time spent actually running the tests.

I also have plans for making the test-queue master fork off another utility process, and this change will help with that one.

/cc @bhuga @tmm1 