### PR TITLE
Fix TEST_QUEUE_SPLIT_GROUPS

### DIFF
--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -30,7 +30,7 @@ module TestQueue
           end
           queue = groups_to_split.map(&:descendant_filtered_examples).flatten
           queue.concat groups_to_keep
-          queue.sort_by!{ |s| -(stats[s.id] || 0) }
+          queue.sort_by!{ |s| -(stats[s.respond_to?(:id) ? s.id : s.to_s] || 0) }
         else
           queue = @rspec.example_groups.sort_by{ |s| -(stats[s.to_s] || 0) }
         end

--- a/lib/test_queue/runner/rspec2.rb
+++ b/lib/test_queue/runner/rspec2.rb
@@ -18,7 +18,17 @@ module RSpec::Core
         begin
           @configuration.run_hook(:before, :suite)
           iterator.map {|g|
-            print "    #{g.description}: "
+            if g.is_a? ::RSpec::Core::Example
+              print "    #{g.full_description}: "
+              example = g
+              g = example.example_group
+              ::RSpec.world.filtered_examples.clear
+              examples = [example]
+              examples.extend(::RSpec::Core::Extensions::Ordered::Examples)
+              ::RSpec.world.filtered_examples[g] = examples
+            else
+              print "    #{g.description}: "
+            end
             start = Time.now
             ret = g.run(reporter)
             diff = Time.now-start

--- a/test/rspec.bats
+++ b/test/rspec.bats
@@ -5,15 +5,27 @@ setup() {
 }
 
 @test "rspec-queue succeeds when all specs pass" {
-  run bundle exec rspec-queue ./test/samples
+  run bundle exec rspec-queue ./test/samples/sample_spec.rb
   assert_status 0
   assert_output_contains "Starting test-queue master"
 }
 
 @test "rspec-queue fails when a spec fails" {
   export FAIL=1
-  run bundle exec rspec-queue ./test/samples
+  run bundle exec rspec-queue ./test/samples/sample_spec.rb
   assert_status 1
   assert_output_contains "1) RSpecFailure fails"
   assert_output_contains "Failure/Error: expect(:foo).to eq :bar"
+}
+
+@test "TEST_QUEUE_SPLIT_GROUPS splits splittable groups" {
+  export TEST_QUEUE_SPLIT_GROUPS=true
+  run bundle exec rspec-queue ./test/samples/sample_split_spec.rb
+  assert_status 0
+
+  # One worker should get tied up with the slow example in the splittable
+  # group. The other worker should run the fast example from the splittable
+  # group plus the two examples in the unsplittable group.
+  assert_output_contains "1 example, 0 failures"
+  assert_output_contains "3 examples, 0 failures"
 }

--- a/test/samples/sample_split_spec.rb
+++ b/test/samples/sample_split_spec.rb
@@ -1,0 +1,22 @@
+require "rspec"
+
+describe 'SplittableGroup' do
+  it 'runs one test' do
+    sleep(1)
+    expect(1).to eq 1
+  end
+
+  it 'runs another test' do
+    expect(2).to eq 2
+  end
+end
+
+describe 'UnsplittableGroup', :no_split => true do
+  it 'runs one test' do
+    expect(1).to eq 1
+  end
+
+  it 'runs another test' do
+    expect(2).to eq 2
+  end
+end

--- a/test/samples/sample_split_spec.rb
+++ b/test/samples/sample_split_spec.rb
@@ -2,7 +2,14 @@ require "rspec"
 
 describe 'SplittableGroup' do
   it 'runs one test' do
-    sleep(1)
+    # Sleep longer in CI to make the distribution of examples across workers
+    # more deterministic.
+    if ENV["CI"]
+      sleep(5)
+    else
+      sleep(1)
+    end
+
     expect(1).to eq 1
   end
 


### PR DESCRIPTION
Using TEST_QUEUE_SPLIT_GROUPS currently raises an exception:

```shellsession
$ TEST_QUEUE_SPLIT_GROUPS=true bundle exec rspec-queue test/samples/sample_spec.rb 
/Users/aroben/dev/test-queue/lib/test_queue/runner/rspec.rb:33:in `block in initialize': undefined method `id' for #<RSpec::Core::Example:0x007fb42a205bd0> (NoMethodError)
    from /Users/aroben/dev/test-queue/lib/test_queue/runner/rspec.rb:33:in `each'
    from /Users/aroben/dev/test-queue/lib/test_queue/runner/rspec.rb:33:in `sort_by'
    from /Users/aroben/dev/test-queue/lib/test_queue/runner/rspec.rb:33:in `sort_by!'
    from /Users/aroben/dev/test-queue/lib/test_queue/runner/rspec.rb:33:in `initialize'
    from /Users/aroben/dev/test-queue/bin/rspec-queue:4:in `new'
    from /Users/aroben/dev/test-queue/bin/rspec-queue:4:in `<top (required)>'
    from /Users/aroben/dev/test-queue/vendor/gems/bin/rspec-queue:23:in `load'
    from /Users/aroben/dev/test-queue/vendor/gems/bin/rspec-queue:23:in `<main>'
```

/cc #26 @sbonebreak @bhuga @tmm1 