### PR TITLE
Test the central master's exit code, not the remote master's

### DIFF
--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -31,9 +31,9 @@ setup() {
 
 @test "multi-master succeeds when all tests pass" {
   export TEST_QUEUE_RELAY_TOKEN=$(date | cksum | cut -d' ' -f1)
-  TEST_QUEUE_SOCKET=0.0.0.0:12345 bundle exec minitest-queue ./test/samples/sample_minitest5.rb &
+  TEST_QUEUE_RELAY=0.0.0.0:12345 bundle exec minitest-queue ./test/samples/sample_minitest5.rb || true &
   sleep 0.1
-  TEST_QUEUE_RELAY=0.0.0.0:12345 run bundle exec minitest-queue ./test/samples/sample_minitest5.rb
+  TEST_QUEUE_SOCKET=0.0.0.0:12345 run bundle exec minitest-queue ./test/samples/sample_minitest5.rb
   wait
 
   assert_status 0
@@ -43,9 +43,9 @@ setup() {
 @test "multi-master fails when a test fails" {
   export FAIL=1
   export TEST_QUEUE_RELAY_TOKEN=$(date | cksum | cut -d' ' -f1)
-  TEST_QUEUE_SOCKET=0.0.0.0:12345 bundle exec minitest-queue ./test/samples/sample_minitest5.rb &
+  TEST_QUEUE_RELAY=0.0.0.0:12345 bundle exec minitest-queue ./test/samples/sample_minitest5.rb || true &
   sleep 0.1
-  TEST_QUEUE_RELAY=0.0.0.0:12345 run bundle exec minitest-queue ./test/samples/sample_minitest5.rb
+  TEST_QUEUE_SOCKET=0.0.0.0:12345 run bundle exec minitest-queue ./test/samples/sample_minitest5.rb
   wait
 
   assert_status 1


### PR DESCRIPTION
In these tests, only a single test fails. That failing test could be run
on either the central master or the remote master. But regardless of
which master it runs on, the central master should fail, so that's the
process whose exit code we should be testing.

Note that the remote master now starts up first. It shouldn't matter
which master starts first (and ideally we'd have tests for both orders)
and doing it this way keeps the test easier to read.

/cc #43 @bhuga 