### PR TITLE
Prune suites not seen in 8 days from .test_queue_stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ install: script/bootstrap
 rvm:
   - 2.2
 env:
+  - SUITE=ruby
   - SUITE=cucumber1-3
   - SUITE=cucumber2-4
   - SUITE=minitest4

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -1,19 +1,23 @@
 require 'socket'
 require 'fileutils'
 require 'securerandom'
+require 'test_queue/stats'
 
 module TestQueue
   class Worker
-    attr_accessor :pid, :status, :output, :stats, :num, :host
+    attr_accessor :pid, :status, :output, :num, :host
     attr_accessor :start_time, :end_time
     attr_accessor :summary, :failure_output
+
+    # Array of TestQueue::Stats::Suite recording all the suites this worker ran.
+    attr_reader :suites
 
     def initialize(pid, num)
       @pid = pid
       @num = num
       @start_time = Time.now
       @output = ''
-      @stats = {}
+      @suites = []
     end
 
     def lines
@@ -23,6 +27,7 @@ module TestQueue
 
   class Runner
     attr_accessor :concurrency, :exit_when_done
+    attr_reader :stats
 
     def initialize(queue, concurrency=nil, socket=nil, relay=nil)
       raise ArgumentError, 'array required' unless Array === queue
@@ -94,12 +99,7 @@ module TestQueue
     end
 
     def stats
-      @stats ||=
-        if File.exists?(file = stats_file)
-          Marshal.load(IO.binread(file)) || {}
-        else
-          {}
-        end
+      @stats ||= Stats.new(stats_file)
     end
 
     # Run the tests.
@@ -128,9 +128,7 @@ module TestQueue
 
       @failures = ''
       @completed.each do |worker|
-        worker.stats.each do |s, val|
-          stats[s.to_s] = val
-        end
+        @stats.record_suites(worker.suites)
 
         summarize_worker(worker)
 
@@ -139,7 +137,7 @@ module TestQueue
         puts "    [%2d] %60s      %4d suites in %.4fs      (pid %d exit %d%s)" % [
           worker.num,
           worker.summary,
-          worker.stats.size,
+          worker.suites.size,
           worker.end_time - worker.start_time,
           worker.pid,
           worker.status.exitstatus,
@@ -156,11 +154,7 @@ module TestQueue
 
       puts
 
-      if @stats
-        File.open(stats_file, 'wb') do |f|
-          f.write Marshal.dump(stats)
-        end
-      end
+      @stats.save
 
       summarize
 
@@ -318,8 +312,8 @@ module TestQueue
           FileUtils.rm(file)
         end
 
-        if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_stats")
-          worker.stats = Marshal.load(IO.binread(file))
+        if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_suites")
+          worker.suites.replace(Marshal.load(IO.binread(file)))
           FileUtils.rm(file)
         end
 

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -128,7 +128,12 @@ module TestQueue
 
       @failures = ''
       @completed.each do |worker|
+        worker.stats.each do |s, val|
+          stats[s.to_s] = val
+        end
+
         summarize_worker(worker)
+
         @failures << worker.failure_output if worker.failure_output
 
         puts "    [%2d] %60s      %4d suites in %.4fs      (pid %d exit %d%s)" % [

--- a/lib/test_queue/runner/cucumber.rb
+++ b/lib/test_queue/runner/cucumber.rb
@@ -55,10 +55,6 @@ module TestQueue
       end
 
       def summarize_worker(worker)
-        worker.stats.each do |s, val|
-          stats[s.to_s] = val
-        end
-
         output                = worker.output.gsub(/\e\[\d+./, '')
         worker.summary        = output.split("\n").grep(/^\d+ (scenarios?|steps?)/).first
         worker.failure_output = output.scan(/^Failing Scenarios:\n(.*)\n\d+ scenarios?/m).join("\n")

--- a/lib/test_queue/runner/cucumber.rb
+++ b/lib/test_queue/runner/cucumber.rb
@@ -34,7 +34,7 @@ module TestQueue
         @features_loader = @runtime.send(:features)
 
         features = @features_loader.is_a?(Array) ? @features_loader : @features_loader.features
-        features = features.sort_by { |s| -(stats[s.to_s] || 0) }
+        features = features.sort_by { |s| -(stats.suite_duration(s.to_s) || 0) }
         super(features)
       end
 

--- a/lib/test_queue/runner/minitest.rb
+++ b/lib/test_queue/runner/minitest.rb
@@ -10,10 +10,6 @@ module TestQueue
   class Runner
     class MiniTest < Runner
       def summarize_worker(worker)
-        worker.stats.each do |s, val|
-          stats[s.to_s] = val
-        end
-
         worker.summary = worker.lines.grep(/, \d+ errors?, /).first
         failures  = worker.lines.select{ |line|
           line if (line =~ /^Finished/) ... (line =~ /, \d+ errors?, /)

--- a/lib/test_queue/runner/minitest4.rb
+++ b/lib/test_queue/runner/minitest4.rb
@@ -56,7 +56,7 @@ module TestQueue
   class Runner
     class MiniTest < Runner
       def initialize
-        tests = ::MiniTest::Unit::TestCase.original_test_suites.sort_by{ |s| -(stats[s.to_s] || 0) }
+        tests = ::MiniTest::Unit::TestCase.original_test_suites.sort_by{ |s| -(stats.suite_duration(s.to_s) || 0) }
         super(tests)
       end
 

--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -52,7 +52,7 @@ module TestQueue
         tests = ::MiniTest::Test.runnables.reject { |s|
           s.runnable_methods.empty?
         }.sort_by { |s|
-          -(stats[s.to_s] || 0)
+          -(stats.suite_duration(s.to_s) || 0)
         }.partition { |s|
           s.test_order == :parallel
         }.reverse.flatten

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -44,10 +44,6 @@ module TestQueue
       end
 
       def summarize_worker(worker)
-        worker.stats.each do |s, val|
-          stats[s] = val
-        end
-
         worker.summary  = worker.lines.grep(/ examples?, /).first
         worker.failure_output = worker.output[/^Failures:\n\n(.*)\n^Finished/m, 1]
       end

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -30,9 +30,9 @@ module TestQueue
           end
           queue = groups_to_split.map(&:descendant_filtered_examples).flatten
           queue.concat groups_to_keep
-          queue.sort_by!{ |s| -(stats[s.respond_to?(:id) ? s.id : s.to_s] || 0) }
+          queue.sort_by!{ |s| -(stats.suite_duration(s.respond_to?(:id) ? s.id : s.to_s) || 0) }
         else
-          queue = @rspec.example_groups.sort_by{ |s| -(stats[s.to_s] || 0) }
+          queue = @rspec.example_groups.sort_by{ |s| -(stats.suite_duration(s.to_s) || 0) }
         end
 
         super(queue)

--- a/lib/test_queue/runner/sample.rb
+++ b/lib/test_queue/runner/sample.rb
@@ -24,8 +24,6 @@ module TestQueue
       end
 
       def summarize_worker(worker)
-        stats.update(worker.stats)
-
         worker.summary  = worker.output.scan(/^\s*(\d+)/).join(', ')
         worker.failure_output = ''
       end

--- a/lib/test_queue/runner/testunit.rb
+++ b/lib/test_queue/runner/testunit.rb
@@ -48,10 +48,6 @@ module TestQueue
       end
 
       def summarize_worker(worker)
-        worker.stats.each do |s, val|
-          stats[s.to_s] = val
-        end
-
         worker.summary = worker.output.split("\n").grep(/^\d+ tests?/).first
         worker.failure_output = worker.output.scan(/^Failure:\n(.*)\n=======================*/m).join("\n")
       end

--- a/lib/test_queue/runner/testunit.rb
+++ b/lib/test_queue/runner/testunit.rb
@@ -37,7 +37,7 @@ module TestQueue
     class TestUnit < Runner
       def initialize
         @suite = Test::Unit::Collector::Descendant.new.collect
-        tests = @suite.tests.sort_by{ |s| -(stats[s.to_s] || 0) }
+        tests = @suite.tests.sort_by{ |s| -(stats.suite_duration(s.to_s) || 0) }
         super(tests)
       end
 

--- a/lib/test_queue/stats.rb
+++ b/lib/test_queue/stats.rb
@@ -1,0 +1,93 @@
+module TestQueue
+  class Stats
+    class Suite
+      attr_reader :name, :duration, :last_seen_at
+
+      def initialize(name, duration, last_seen_at)
+        @name = name
+        @duration = duration
+        @last_seen_at = last_seen_at
+
+        freeze
+      end
+
+      def ==(other)
+        other &&
+          name == other.name &&
+          duration == other.duration &&
+          last_seen_at == other.last_seen_at
+      end
+      alias_method :eql?, :==
+
+      def to_h
+        { :name => name, :duration => duration, :last_seen_at => last_seen_at.to_i }
+      end
+
+      def self.from_hash(hash)
+        self.new(hash.fetch(:name),
+                 hash.fetch(:duration),
+                 Time.at(hash.fetch(:last_seen_at)))
+      end
+    end
+
+    def initialize(path)
+      @path = path
+      @suites = {}
+      load
+    end
+
+    def all_suites
+      @suites.values
+    end
+
+    def suite_duration(name)
+      suite = @suites[name]
+      suite && suite.duration
+    end
+
+    def record_suites(suites)
+      suites.each do |suite|
+        @suites[suite.name] = suite
+      end
+    end
+
+    def save
+      prune
+
+      File.open(@path, "wb") do |f|
+        Marshal.dump(to_h, f)
+      end
+    end
+
+    private
+
+    CURRENT_VERSION = 1
+
+    def to_h
+      suites = @suites.each_value.map(&:to_h)
+
+      { :version => CURRENT_VERSION, :suites => suites }
+    end
+
+    def load
+      data = begin
+               File.open(@path, "rb") { |f| Marshal.load(f) }
+             rescue Errno::ENOENT, EOFError, TypeError
+             end
+      return unless data && data.is_a?(Hash) && data[:version] == CURRENT_VERSION
+      data[:suites].each do |suite_hash|
+        suite = Suite.from_hash(suite_hash)
+        @suites[suite.name] = suite
+      end
+    end
+
+    EIGHT_DAYS_S = 8 * 24 * 60 * 60
+
+    def prune
+      earliest = Time.now - EIGHT_DAYS_S
+      @suites.delete_if do |name, suite|
+        suite.last_seen_at < earliest
+      end
+    end
+  end
+end

--- a/script/cibuild
+++ b/script/cibuild
@@ -2,6 +2,10 @@
 
 set -ex
 
+if [ "$SUITE" = "ruby" ]; then
+  exec script/spec
+fi
+
 export TEST_QUEUE_WORKERS=2 TEST_QUEUE_VERBOSE=1
 
 if [ -f "Gemfile-$SUITE" ]; then

--- a/script/spec
+++ b/script/spec
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -ex
+
+export BUNDLE_GEMFILE=Gemfile-rspec3-2
+bundle install
+bundle exec rspec spec

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe TestQueue::Stats do
       stats = TestQueue::Stats.new(@path)
       expect(stats.all_suites).to be_empty
     end
+
+    it "ignores stats files with a wrong version number" do
+      File.write(@path, Marshal.dump({ :version => 1e8, :suites => "boom" }))
+      stats = TestQueue::Stats.new(@path)
+      expect(stats.all_suites).to be_empty
+    end
   end
 
   it "can save and load data" do

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -1,0 +1,70 @@
+require "fileutils"
+require "tempfile"
+require "test_queue/stats"
+
+RSpec.describe TestQueue::Stats do
+  before do
+    Tempfile.open("test_queue_stats") do |f|
+      @path = f.path
+      f.close!
+    end
+  end
+
+  after do
+    FileUtils.rm_f(@path)
+  end
+
+  describe "#initialize" do
+    it "ignores empty stats files" do
+      File.write(@path, "")
+      stats = TestQueue::Stats.new(@path)
+      expect(stats.all_suites).to be_empty
+    end
+
+    it "ignores invalid data in the stats files" do
+      File.write(@path, "this is not marshal data")
+      stats = TestQueue::Stats.new(@path)
+      expect(stats.all_suites).to be_empty
+    end
+
+    it "ignores badly-typed data in the stats file" do
+      File.write(@path, Marshal.dump(["heyyy"]))
+      stats = TestQueue::Stats.new(@path)
+      expect(stats.all_suites).to be_empty
+    end
+  end
+
+  it "can save and load data" do
+    stats = TestQueue::Stats.new(@path)
+    time = truncated_now
+    suites = [
+      TestQueue::Stats::Suite.new("Suite1", 0.3, time),
+      TestQueue::Stats::Suite.new("Suite2", 0.5, time + 5),
+    ]
+    stats.record_suites(suites)
+    stats.save
+
+    stats = TestQueue::Stats.new(@path)
+    expect(stats.all_suites.sort_by(&:name)).to eq(suites)
+  end
+
+  it "prunes suites not seen in the last 8 days" do
+    stats = TestQueue::Stats.new(@path)
+    time = truncated_now
+    suites = [
+      TestQueue::Stats::Suite.new("Suite1", 0.3, time),
+      TestQueue::Stats::Suite.new("Suite2", 0.5, time - (8 * 24 * 60 * 60) - 2),
+      TestQueue::Stats::Suite.new("Suite3", 0.6, time - (7 * 24 * 60 * 60)),
+    ]
+    stats.record_suites(suites)
+    stats.save
+
+    stats = TestQueue::Stats.new(@path)
+    expect(stats.all_suites.map(&:name).sort).to eq(%w[Suite1 Suite3])
+  end
+
+  # Returns Time.now rounded down to the nearest second.
+  def truncated_now
+    Time.at(Time.now.to_i)
+  end
+end


### PR DESCRIPTION
Without this, .test_queue_stats grows without bound as a project's tests
evolve. New suites get added but old ones never get removed.

The stats file is now managed by a TestQueue::Stats class. Each suite is
reprsented by a TestQueue::Stats::Suite value object. I added some
simple specs that Travis will run.

The format of the stats file has changed. Old stats will be ignored and
overwritten with new-format stats.

/cc @tmm1 @bhuga 