### PR TITLE
Make TEST_QUEUE_SPLIT_GROUPS test more deterministic

### DIFF
--- a/test/rspec.bats
+++ b/test/rspec.bats
@@ -23,9 +23,16 @@ setup() {
   run bundle exec rspec-queue ./test/samples/sample_split_spec.rb
   assert_status 0
 
-  # One worker should get tied up with the slow example in the splittable
-  # group. The other worker should run the fast example from the splittable
-  # group plus the two examples in the unsplittable group.
-  assert_output_contains "1 example, 0 failures"
-  assert_output_contains "3 examples, 0 failures"
+  assert_output_matches '\[ 1\] +1 example, 0 failures'
+  assert_output_matches '\[ 2\] +1 example, 0 failures'
+}
+
+@test "TEST_QUEUE_SPLIT_GROUPS does not split unsplittable groups" {
+  export TEST_QUEUE_SPLIT_GROUPS=true
+  export NOSPLIT=1
+  run bundle exec rspec-queue ./test/samples/sample_split_spec.rb
+  assert_status 0
+
+  assert_output_contains "2 examples, 0 failures"
+  assert_output_contains "0 examples, 0 failures"
 }

--- a/test/samples/sample_split_spec.rb
+++ b/test/samples/sample_split_spec.rb
@@ -1,29 +1,17 @@
 require "rspec"
 
-describe 'SplittableGroup' do
-  it 'runs one test' do
-    # Sleep longer in CI to make the distribution of examples across workers
-    # more deterministic.
-    if ENV["CI"]
-      sleep(5)
-    else
-      sleep(1)
+describe 'SplittableGroup', :no_split => !!ENV["NOSPLIT"] do
+  2.times do |i|
+    it "runs test #{i}" do
+      # Sleep longer in CI to make the distribution of examples across workers
+      # more deterministic.
+      if ENV["CI"]
+        sleep(5)
+      else
+        sleep(1)
+      end
+
+      expect(1).to eq 1
     end
-
-    expect(1).to eq 1
-  end
-
-  it 'runs another test' do
-    expect(2).to eq 2
-  end
-end
-
-describe 'UnsplittableGroup', :no_split => true do
-  it 'runs one test' do
-    expect(1).to eq 1
-  end
-
-  it 'runs another test' do
-    expect(2).to eq 2
   end
 end

--- a/test/testlib.bash
+++ b/test/testlib.bash
@@ -51,3 +51,21 @@ refute_output_contains() {
   }
   return 0
 }
+
+assert_output_matches() {
+  echo "$output" | egrep --quiet "$@" || {
+    echo "Expected to \"$@\" to match within:"
+    echo "$output"
+    return 1
+  }
+  return 0
+}
+
+refute_output_matches() {
+  assert_output_matches "$@" && {
+    echo "Expected \"$@\" not to match within:"
+    echo "$output"
+    return 1
+  }
+  return 0
+}

--- a/test/testlib.bash
+++ b/test/testlib.bash
@@ -35,7 +35,7 @@ assert_status() {
 }
 
 assert_output_contains() {
-  echo "$output" | grep -q "$@" || {
+  echo "$output" | fgrep --quiet "$@" || {
     echo "Expected to find \"$@\" in:"
     echo "$output"
     return 1


### PR DESCRIPTION
We now use a single group containing two slow examples. When split, we should end up with one example per worker.

/cc @bhuga