### PR TITLE
Require test files in workers instead of master

### DIFF
--- a/bin/minitest-queue
+++ b/bin/minitest-queue
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
 require 'test_queue'
 require 'test_queue/runner/minitest'
-ARGV.each{ |f| require(File.absolute_path(f)) }
 TestQueue::Runner::MiniTest.new.execute

--- a/bin/testunit-queue
+++ b/bin/testunit-queue
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
 require 'test_queue'
 require 'test_queue/runner/testunit'
-ARGV.each{ |f| require(File.absolute_path(f)) }
 TestQueue::Runner::TestUnit.new.execute

--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -94,7 +94,7 @@ module TestQueue
       suite = @loaded_suites[suite_name]
       return suite if suite
 
-      @test_framework.suites_from_path(path).each do |name, suite|
+      @test_framework.suites_from_file(path).each do |name, suite|
         @loaded_suites[name] = suite
       end
       @loaded_suites[suite_name]

--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -39,6 +39,7 @@ module TestQueue
           item = Marshal.load(data)
           break if item.nil? || item.empty?
           if item == "WAIT"
+            $0 = "#{@procline} - Waiting for work"
             sleep 0.1
             next
           end

--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -1,13 +1,13 @@
 module TestQueue
   class Iterator
-    attr_reader :suites, :sock
+    attr_reader :sock
 
-    def initialize(sock, suites, filter=nil, early_failure_limit: nil)
+    def initialize(test_framework, sock, filter=nil, early_failure_limit: nil)
+      @test_framework = test_framework
       @done = false
       @suite_stats = []
       @procline = $0
       @sock = sock
-      @suites = suites
       @filter = filter
       if @sock =~ /^(.+):(\d+)$/
         @tcp_address = $1
@@ -38,7 +38,15 @@ module TestQueue
           client.close
           item = Marshal.load(data)
           break if item.nil? || item.empty?
-          suite = @suites[item]
+          if item == "WAIT"
+            sleep 0.1
+            next
+          end
+          suite_name, path = item
+          suite = load_suite(suite_name, path)
+
+          # Maybe we were told to load a suite that doesn't exist anymore.
+          next unless suite
 
           $0 = "#{@procline} - #{suite.respond_to?(:description) ? suite.description : suite}"
           start = Time.now
@@ -47,8 +55,7 @@ module TestQueue
           else
             yield suite
           end
-          key = suite.respond_to?(:id) ? suite.id : suite.to_s
-          @suite_stats << TestQueue::Stats::Suite.new(key, Time.now - start, Time.now)
+          @suite_stats << TestQueue::Stats::Suite.new(suite_name, path, Time.now - start, Time.now)
           @failures += suite.failure_count if suite.respond_to? :failure_count
         else
           break
@@ -79,6 +86,17 @@ module TestQueue
 
     def empty?
       false
+    end
+
+    def load_suite(suite_name, path)
+      @loaded_suites ||= {}
+      suite = @loaded_suites[suite_name]
+      return suite if suite
+
+      @test_framework.suites_from_path(path).each do |name, suite|
+        @loaded_suites[name] = suite
+      end
+      @loaded_suites[suite_name]
     end
   end
 end

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -47,7 +47,7 @@ module TestQueue
 
       @whitelist = Set.new
 
-      all_files = @test_framework.all_suite_paths.to_set
+      all_files = @test_framework.all_suite_files.to_set
       @queue = @stats.all_suites
         .select { |suite| all_files.include?(suite.path) }
         .sort_by { |suite| -suite.duration }
@@ -256,8 +256,8 @@ module TestQueue
     def discover_suites
       return if relay?
       @discovering_suites_pid = fork do
-        @test_framework.all_suite_paths.each do |path|
-          @test_framework.suites_from_path(path).each do |suite_name, suite|
+        @test_framework.all_suite_files.each do |path|
+          @test_framework.suites_from_file(path).each do |suite_name, suite|
             @server.connect_address.connect do |sock|
               sock.puts("NEW SUITE #{Marshal.dump([suite_name, path])}")
             end

--- a/lib/test_queue/runner/cucumber.rb
+++ b/lib/test_queue/runner/cucumber.rb
@@ -72,6 +72,12 @@ module TestQueue
     class Cucumber < TestFramework
       class FakeKernel
         def exit(n)
+          if $!
+            # Let Cucumber exit for raised exceptions.
+            Kernel.exit(n)
+          end
+          # Don't let Cucumber exit to indicate test failures. We want to
+          # return the number of failures from #run_worker instead.
         end
       end
 

--- a/lib/test_queue/runner/cucumber.rb
+++ b/lib/test_queue/runner/cucumber.rb
@@ -97,7 +97,7 @@ module TestQueue
         end
       end
 
-      def suites_from_path(path)
+      def suites_from_file(path)
         if defined?(::Cucumber::Core::Gherkin::Document)
           source = ::Cucumber::Runtime::NormalisedEncodingFile.read(path)
           doc = ::Cucumber::Core::Gherkin::Document.new(path, source)

--- a/lib/test_queue/runner/cucumber.rb
+++ b/lib/test_queue/runner/cucumber.rb
@@ -89,7 +89,7 @@ module TestQueue
         @runtime ||= ::Cucumber::Runtime.new(cli.configuration)
       end
 
-      def all_suite_paths
+      def all_suite_files
         if runtime.respond_to?(:feature_files, true)
           runtime.send(:feature_files)
         else

--- a/lib/test_queue/runner/cucumber.rb
+++ b/lib/test_queue/runner/cucumber.rb
@@ -16,41 +16,47 @@ module Cucumber
   end
 
   class Runtime
-    attr_writer :features
+    if defined?(::Cucumber::Runtime::FeaturesLoader)
+      # Without this module, Runtime#features would load all features specified
+      # on the command line. We want to avoid that and load only the features
+      # each worker needs ourselves, so we override the default behavior to let
+      # us put our iterator in place without loading any features directly.
+      module InjectableFeatures
+        def features
+          return @features if defined?(@features)
+          super
+        end
+
+        def features=(iterator)
+          @features = ::Cucumber::Ast::Features.new
+          @features.features = iterator
+        end
+      end
+
+      prepend InjectableFeatures
+    else
+      attr_writer :features
+    end
   end
 end
 
 module TestQueue
   class Runner
     class Cucumber < Runner
-      class FakeKernel
-        def exit(n)
-        end
-      end
-
       def initialize
-        @cli             = ::Cucumber::Cli::Main.new(ARGV.dup, $stdin, $stdout, $stderr, FakeKernel.new)
-        @runtime         = ::Cucumber::Runtime.new(@cli.configuration)
-        @features_loader = @runtime.send(:features)
-
-        features = @features_loader.is_a?(Array) ? @features_loader : @features_loader.features
-        features = features.sort_by { |s| -(stats.suite_duration(s.to_s) || 0) }
-        super(features)
+        super(TestFramework::Cucumber.new)
       end
 
       def run_worker(iterator)
-        if @features_loader.is_a?(Array)
-          @runtime.features = iterator
-        else
-          @features_loader.features = iterator
-        end
+        runtime = @test_framework.runtime
+        runtime.features = iterator
 
-        @cli.execute!(@runtime)
+        @test_framework.cli.execute!(runtime)
 
-        if @runtime.respond_to?(:summary_report, true)
-          @runtime.send(:summary_report).test_cases.total_failed
+        if runtime.respond_to?(:summary_report, true)
+          runtime.send(:summary_report).test_cases.total_failed
         else
-          @runtime.results.scenarios(:failed).size
+          runtime.results.scenarios(:failed).size
         end
       end
 
@@ -58,6 +64,45 @@ module TestQueue
         output                = worker.output.gsub(/\e\[\d+./, '')
         worker.summary        = output.split("\n").grep(/^\d+ (scenarios?|steps?)/).first
         worker.failure_output = output.scan(/^Failing Scenarios:\n(.*)\n\d+ scenarios?/m).join("\n")
+      end
+    end
+  end
+
+  class TestFramework
+    class Cucumber < TestFramework
+      class FakeKernel
+        def exit(n)
+        end
+      end
+
+      def cli
+        @cli ||= ::Cucumber::Cli::Main.new(ARGV.dup, $stdin, $stdout, $stderr, FakeKernel.new)
+      end
+
+      def runtime
+        @runtime ||= ::Cucumber::Runtime.new(cli.configuration)
+      end
+
+      def all_suite_paths
+        if runtime.respond_to?(:feature_files, true)
+          runtime.send(:feature_files)
+        else
+          cli.configuration.feature_files
+        end
+      end
+
+      def suites_from_path(path)
+        if defined?(::Cucumber::Core::Gherkin::Document)
+          source = ::Cucumber::Runtime::NormalisedEncodingFile.read(path)
+          doc = ::Cucumber::Core::Gherkin::Document.new(path, source)
+          [[File.basename(doc.uri), doc]]
+        else
+          loader =
+            ::Cucumber::Runtime::FeaturesLoader.new([path],
+                                                    cli.configuration.filters,
+                                                    cli.configuration.tag_expression)
+          loader.features.map { |feature| [feature.title, feature] }
+        end
       end
     end
   end

--- a/lib/test_queue/runner/minitest4.rb
+++ b/lib/test_queue/runner/minitest4.rb
@@ -72,7 +72,7 @@ module TestQueue
 
   class TestFramework
     class MiniTest < TestFramework
-      def all_suite_paths
+      def all_suite_files
         ARGV
       end
 

--- a/lib/test_queue/runner/minitest4.rb
+++ b/lib/test_queue/runner/minitest4.rb
@@ -1,4 +1,5 @@
 require 'test_queue/runner'
+require 'set'
 require 'stringio'
 
 class MiniTestQueueRunner < MiniTest::Unit
@@ -56,13 +57,31 @@ module TestQueue
   class Runner
     class MiniTest < Runner
       def initialize
-        tests = ::MiniTest::Unit::TestCase.original_test_suites.sort_by{ |s| -(stats.suite_duration(s.to_s) || 0) }
-        super(tests)
+        if ::MiniTest::Unit::TestCase.original_test_suites.any?
+          fail "Do not `require` test files. Pass them via ARGV instead and they will be required as needed."
+        end
+        super(TestFramework::MiniTest.new)
       end
 
       def run_worker(iterator)
         ::MiniTest::Unit::TestCase.test_suites = iterator
         ::MiniTest::Unit.new.run
+      end
+    end
+  end
+
+  class TestFramework
+    class MiniTest < TestFramework
+      def all_suite_paths
+        ARGV
+      end
+
+      def suites_from_path(path)
+        ::MiniTest::Unit::TestCase.reset
+        require File.absolute_path(path)
+        ::MiniTest::Unit::TestCase.original_test_suites.map { |suite|
+          [suite.name, suite]
+        }
       end
     end
   end

--- a/lib/test_queue/runner/minitest4.rb
+++ b/lib/test_queue/runner/minitest4.rb
@@ -76,7 +76,7 @@ module TestQueue
         ARGV
       end
 
-      def suites_from_path(path)
+      def suites_from_file(path)
         ::MiniTest::Unit::TestCase.reset
         require File.absolute_path(path)
         ::MiniTest::Unit::TestCase.original_test_suites.map { |suite|

--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -71,7 +71,7 @@ module TestQueue
 
   class TestFramework
     class MiniTest < TestFramework
-      def all_suite_paths
+      def all_suite_files
         ARGV
       end
 

--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -75,7 +75,7 @@ module TestQueue
         ARGV
       end
 
-      def suites_from_path(path)
+      def suites_from_file(path)
         ::MiniTest::Test.reset
         require File.absolute_path(path)
         ::MiniTest::Test.runnables

--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -3,9 +3,6 @@ require 'test_queue/runner'
 module MiniTest
   def self.__run reporter, options
     suites = Runnable.runnables
-
-    # Run the serial tests first after they complete, run the parallels tests
-    # We already sort suites based on its test_order at TestQueue::Runner::Minitest#initialize.
     suites.map { |suite| suite.run reporter, options }
   end
 
@@ -19,6 +16,16 @@ module MiniTest
     def self.runnables= runnables
       @@runnables = runnables
     end
+
+    # Synchronize all tests, even serial ones.
+    #
+    # Minitest runs serial tests before parallel ones to ensure the
+    # unsynchronized serial tests don't overlap the parallel tests. But since
+    # the test-queue master hands out tests without actually loading their
+    # code, there's no way to know which are parallel and which are serial.
+    # Synchronizing serial tests does add some overhead, but hopefully this is
+    # outweighed by the speed benefits of using test-queue.
+    def _synchronize; Test.io_lock.synchronize { yield }; end
   end
 
   class ProgressReporter
@@ -49,19 +56,31 @@ module TestQueue
   class Runner
     class MiniTest < Runner
       def initialize
-        tests = ::MiniTest::Test.runnables.reject { |s|
-          s.runnable_methods.empty?
-        }.sort_by { |s|
-          -(stats.suite_duration(s.to_s) || 0)
-        }.partition { |s|
-          s.test_order == :parallel
-        }.reverse.flatten
-        super(tests)
+        if ::MiniTest::Test.runnables.any? { |r| r.runnable_methods.any? }
+          fail "Do not `require` test files. Pass them via ARGV instead and they will be required as needed."
+        end
+        super(TestFramework::MiniTest.new)
       end
 
       def run_worker(iterator)
         ::MiniTest::Test.runnables = iterator
         ::MiniTest.run ? 0 : 1
+      end
+    end
+  end
+
+  class TestFramework
+    class MiniTest < TestFramework
+      def all_suite_paths
+        ARGV
+      end
+
+      def suites_from_path(path)
+        ::MiniTest::Test.reset
+        require File.absolute_path(path)
+        ::MiniTest::Test.runnables
+          .reject { |s| s.runnable_methods.empty? }
+          .map { |s| [s.name, s] }
       end
     end
   end

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -45,7 +45,7 @@ module TestQueue
         ::RSpec.configuration.files_to_run.uniq
       end
 
-      def suites_from_path(path)
+      def suites_from_file(path)
         ::RSpec.world.reset
         load path
         split_groups(::RSpec.world.example_groups).map { |example_or_group|

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -37,7 +37,7 @@ module TestQueue
 
   class TestFramework
     class RSpec < TestFramework
-      def all_suite_paths
+      def all_suite_files
         options = ::RSpec::Core::ConfigurationOptions.new(ARGV)
         options.parse_options if options.respond_to?(:parse_options)
         options.configure(::RSpec.configuration)

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -20,32 +20,63 @@ module TestQueue
   class Runner
     class RSpec < Runner
       def initialize
-        @rspec = ::RSpec::Core::QueueRunner.new
-        @split_groups = ENV['TEST_QUEUE_SPLIT_GROUPS'] && ENV['TEST_QUEUE_SPLIT_GROUPS'].strip.downcase == 'true'
-        if @split_groups
-          groups = @rspec.example_groups
-          groups_to_split, groups_to_keep = [], []
-          groups.each do |group|
-            (group.metadata[:no_split] ? groups_to_keep : groups_to_split) << group
-          end
-          queue = groups_to_split.map(&:descendant_filtered_examples).flatten
-          queue.concat groups_to_keep
-          queue.sort_by!{ |s| -(stats.suite_duration(s.respond_to?(:id) ? s.id : s.to_s) || 0) }
-        else
-          queue = @rspec.example_groups.sort_by{ |s| -(stats.suite_duration(s.to_s) || 0) }
-        end
-
-        super(queue)
+        super(TestFramework::RSpec.new)
       end
 
-
       def run_worker(iterator)
-        @rspec.run_each(iterator).to_i
+        rspec = ::RSpec::Core::QueueRunner.new
+        rspec.run_each(iterator).to_i
       end
 
       def summarize_worker(worker)
         worker.summary  = worker.lines.grep(/ examples?, /).first
         worker.failure_output = worker.output[/^Failures:\n\n(.*)\n^Finished/m, 1]
+      end
+    end
+  end
+
+  class TestFramework
+    class RSpec < TestFramework
+      def all_suite_paths
+        options = ::RSpec::Core::ConfigurationOptions.new(ARGV)
+        options.parse_options if options.respond_to?(:parse_options)
+        options.configure(::RSpec.configuration)
+
+        ::RSpec.configuration.files_to_run.uniq
+      end
+
+      def suites_from_path(path)
+        ::RSpec.world.reset
+        load path
+        split_groups(::RSpec.world.example_groups).map { |example_or_group|
+          name = if example_or_group.respond_to?(:id)
+                   example_or_group.id
+                 elsif example_or_group.respond_to?(:full_description)
+                   example_or_group.full_description
+                 else
+                   example_or_group.metadata[:example_group][:full_description]
+                 end
+          [name, example_or_group]
+        }
+      end
+
+      private
+
+      def split_groups(groups)
+        return groups unless split_groups?
+
+        groups_to_split, groups_to_keep = [], []
+        groups.each do |group|
+          (group.metadata[:no_split] ? groups_to_keep : groups_to_split) << group
+        end
+        queue = groups_to_split.flat_map(&:descendant_filtered_examples)
+        queue.concat groups_to_keep
+        queue
+      end
+
+      def split_groups?
+        return @split_groups if defined?(@split_groups)
+        @split_groups = ENV['TEST_QUEUE_SPLIT_GROUPS'] && ENV['TEST_QUEUE_SPLIT_GROUPS'].strip.downcase == 'true'
       end
     end
   end

--- a/lib/test_queue/runner/rspec2.rb
+++ b/lib/test_queue/runner/rspec2.rb
@@ -6,13 +6,6 @@ module RSpec::Core
       @configuration.error_stream  = $stderr
     end
 
-    def example_groups
-      @options.configure(@configuration)
-      @configuration.load_spec_files
-      @world.announce_filters
-      @world.example_groups
-    end
-
     def run_each(iterator)
       @configuration.reporter.report(0, @configuration.randomize? ? @configuration.seed : nil) do |reporter|
         begin

--- a/lib/test_queue/runner/rspec3.rb
+++ b/lib/test_queue/runner/rspec3.rb
@@ -20,13 +20,8 @@ module RSpec::Core
       super(options)
     end
 
-    def example_groups
-      setup($stderr, $stdout)
-      @world.ordered_example_groups
-    end
-
     def run_specs(iterator)
-      @configuration.reporter.report(@world.ordered_example_groups.count) do |reporter|
+      @configuration.reporter.report(0) do |reporter|
         @configuration.with_suite_hooks do
           iterator.map { |g|
             start = Time.now

--- a/lib/test_queue/runner/testunit.rb
+++ b/lib/test_queue/runner/testunit.rb
@@ -58,7 +58,7 @@ module TestQueue
 
   class TestFramework
     class TestUnit < TestFramework
-      def all_suite_paths
+      def all_suite_files
         ARGV
       end
 

--- a/lib/test_queue/runner/testunit.rb
+++ b/lib/test_queue/runner/testunit.rb
@@ -36,12 +36,14 @@ module TestQueue
   class Runner
     class TestUnit < Runner
       def initialize
-        @suite = Test::Unit::Collector::Descendant.new.collect
-        tests = @suite.tests.sort_by{ |s| -(stats.suite_duration(s.to_s) || 0) }
-        super(tests)
+        if Test::Unit::Collector::Descendant.new.collect.tests.any?
+          fail "Do not `require` test files. Pass them via ARGV instead and they will be required as needed."
+        end
+        super(TestFramework::TestUnit.new)
       end
 
       def run_worker(iterator)
+        @suite = Test::Unit::TestSuite.new("specified by test-queue master")
         @suite.iterator = iterator
         res = Test::Unit::UI::Console::TestRunner.new(@suite).start
         res.run_count - res.pass_count
@@ -50,6 +52,22 @@ module TestQueue
       def summarize_worker(worker)
         worker.summary = worker.output.split("\n").grep(/^\d+ tests?/).first
         worker.failure_output = worker.output.scan(/^Failure:\n(.*)\n=======================*/m).join("\n")
+      end
+    end
+  end
+
+  class TestFramework
+    class TestUnit < TestFramework
+      def all_suite_paths
+        ARGV
+      end
+
+      def suites_from_path(path)
+        Test::Unit::TestCase::DESCENDANTS.clear
+        require File.absolute_path(path)
+        Test::Unit::Collector::Descendant.new.collect.tests.map { |suite|
+          [suite.name, suite]
+        }
       end
     end
   end

--- a/lib/test_queue/runner/testunit.rb
+++ b/lib/test_queue/runner/testunit.rb
@@ -62,7 +62,7 @@ module TestQueue
         ARGV
       end
 
-      def suites_from_path(path)
+      def suites_from_file(path)
         Test::Unit::TestCase::DESCENDANTS.clear
         require File.absolute_path(path)
         Test::Unit::Collector::Descendant.new.collect.tests.map { |suite|

--- a/lib/test_queue/stats.rb
+++ b/lib/test_queue/stats.rb
@@ -1,10 +1,11 @@
 module TestQueue
   class Stats
     class Suite
-      attr_reader :name, :duration, :last_seen_at
+      attr_reader :name, :path, :duration, :last_seen_at
 
-      def initialize(name, duration, last_seen_at)
+      def initialize(name, path, duration, last_seen_at)
         @name = name
+        @path = path
         @duration = duration
         @last_seen_at = last_seen_at
 
@@ -14,17 +15,19 @@ module TestQueue
       def ==(other)
         other &&
           name == other.name &&
+          path == other.path &&
           duration == other.duration &&
           last_seen_at == other.last_seen_at
       end
       alias_method :eql?, :==
 
       def to_h
-        { :name => name, :duration => duration, :last_seen_at => last_seen_at.to_i }
+        { :name => name, :path => path, :duration => duration, :last_seen_at => last_seen_at.to_i }
       end
 
       def self.from_hash(hash)
         self.new(hash.fetch(:name),
+                 hash.fetch(:path),
                  hash.fetch(:duration),
                  Time.at(hash.fetch(:last_seen_at)))
       end
@@ -40,9 +43,8 @@ module TestQueue
       @suites.values
     end
 
-    def suite_duration(name)
-      suite = @suites[name]
-      suite && suite.duration
+    def suite(name)
+      @suites[name]
     end
 
     def record_suites(suites)
@@ -61,7 +63,7 @@ module TestQueue
 
     private
 
-    CURRENT_VERSION = 1
+    CURRENT_VERSION = 2
 
     def to_h
       suites = @suites.each_value.map(&:to_h)

--- a/lib/test_queue/test_framework.rb
+++ b/lib/test_queue/test_framework.rb
@@ -1,0 +1,29 @@
+module TestQueue
+  # This class provides an abstraction over the various test frameworks we
+  # support. The framework-specific subclasses are defined in the various
+  # test_queue/runner/* files.
+  class TestFramework
+    # Return all file paths to load test suites from.
+    #
+    # An example implementation might just return files passed on the command
+    # line, or defer to the underlying test framework to determine which files
+    # to load.
+    #
+    # Returns an Enumerable of String file paths.
+    def all_suite_paths
+      raise NotImplementedError
+    end
+
+    # Load all suites from the specified path.
+    #
+    # path - String file path to load suites from
+    #
+    # Returns an Enumerable of tuples containing:
+    #   suite_name   - String that uniquely identifies this suite
+    #   suite        - Framework-specific object that can be used to actually
+    #                  run the suite
+    def suites_from_path(path)
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/test_queue/test_framework.rb
+++ b/lib/test_queue/test_framework.rb
@@ -10,11 +10,11 @@ module TestQueue
     # to load.
     #
     # Returns an Enumerable of String file paths.
-    def all_suite_paths
+    def all_suite_files
       raise NotImplementedError
     end
 
-    # Load all suites from the specified path.
+    # Load all suites from the specified file path.
     #
     # path - String file path to load suites from
     #
@@ -22,7 +22,7 @@ module TestQueue
     #   suite_name   - String that uniquely identifies this suite
     #   suite        - Framework-specific object that can be used to actually
     #                  run the suite
-    def suites_from_path(path)
+    def suites_from_file(path)
       raise NotImplementedError
     end
   end

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe TestQueue::Stats do
     stats = TestQueue::Stats.new(@path)
     time = truncated_now
     suites = [
-      TestQueue::Stats::Suite.new("Suite1", 0.3, time),
-      TestQueue::Stats::Suite.new("Suite2", 0.5, time + 5),
+      TestQueue::Stats::Suite.new("Suite1", "foo.rb", 0.3, time),
+      TestQueue::Stats::Suite.new("Suite2", "bar.rb", 0.5, time + 5),
     ]
     stats.record_suites(suites)
     stats.save
@@ -58,9 +58,9 @@ RSpec.describe TestQueue::Stats do
     stats = TestQueue::Stats.new(@path)
     time = truncated_now
     suites = [
-      TestQueue::Stats::Suite.new("Suite1", 0.3, time),
-      TestQueue::Stats::Suite.new("Suite2", 0.5, time - (8 * 24 * 60 * 60) - 2),
-      TestQueue::Stats::Suite.new("Suite3", 0.6, time - (7 * 24 * 60 * 60)),
+      TestQueue::Stats::Suite.new("Suite1", "foo.rb", 0.3, time),
+      TestQueue::Stats::Suite.new("Suite2", "bar.rb", 0.5, time - (8 * 24 * 60 * 60) - 2),
+      TestQueue::Stats::Suite.new("Suite3", "baz.rb", 0.6, time - (7 * 24 * 60 * 60)),
     ]
     stats.record_suites(suites)
     stats.save

--- a/test/cucumber.bats
+++ b/test/cucumber.bats
@@ -36,8 +36,9 @@ teardown() {
 @test "cucumber-queue fails when given a malformed feature" {
   [ -f README.md ]
   run bundle exec cucumber-queue README.md --require test/samples/features/step_definitions
-  assert_status 1
-  # Cucumber 1 and 2 give different error output here.
+
+  # Cucumber 1 and 2 fail in different ways.
+  refute_status 0
   assert_output_matches 'Aborting: Discovering suites failed\.|README\.md: Parser errors:'
 }
 

--- a/test/cucumber.bats
+++ b/test/cucumber.bats
@@ -30,14 +30,15 @@ teardown() {
 @test "cucumber-queue fails when given a missing feature" {
   run bundle exec cucumber-queue test/samples/does_not_exist.feature --require test/samples/features/step_definitions
   assert_status 1
-  assert_output_contains "No such file or directory"
+  assert_output_contains "Aborting: Discovering suites failed."
 }
 
 @test "cucumber-queue fails when given a malformed feature" {
   [ -f README.md ]
   run bundle exec cucumber-queue README.md --require test/samples/features/step_definitions
   assert_status 1
-  assert_output_contains "No such file or directory"
+  # Cucumber 1 and 2 give different error output here.
+  assert_output_matches 'Aborting: Discovering suites failed\.|README\.md: Parser errors:'
 }
 
 @test "cucumber-queue handles test file being deleted" {

--- a/test/cucumber.bats
+++ b/test/cucumber.bats
@@ -1,7 +1,15 @@
 load "testlib"
 
+SCRATCH=tmp/cucumber-tests
+
 setup() {
   require_gem "cucumber" ">= 1.0"
+  rm -rf $SCRATCH
+  mkdir -p $SCRATCH
+}
+
+teardown() {
+  rm -rf $SCRATCH
 }
 
 @test "cucumber-queue succeeds when all features pass" {
@@ -17,4 +25,31 @@ setup() {
   assert_output_contains "Starting test-queue master"
   assert_output_contains "cucumber test/samples/features/bad.feature:2 # Scenario: failure"
   assert_output_contains "cucumber test/samples/features/sample2.feature:26 # Scenario: failure"
+}
+
+@test "cucumber-queue fails when given a missing feature" {
+  run bundle exec cucumber-queue test/samples/does_not_exist.feature --require test/samples/features/step_definitions
+  assert_status 1
+  assert_output_contains "No such file or directory"
+}
+
+@test "cucumber-queue fails when given a malformed feature" {
+  [ -f README.md ]
+  run bundle exec cucumber-queue README.md --require test/samples/features/step_definitions
+  assert_status 1
+  assert_output_contains "No such file or directory"
+}
+
+@test "cucumber-queue handles test file being deleted" {
+  cp test/samples/features/*.feature $SCRATCH
+
+  run bundle exec cucumber-queue $SCRATCH --require test/samples/features/step_definitions
+  assert_status 0
+  assert_output_matches "Feature: Foobar$"
+
+  rm $SCRATCH/sample.feature
+
+  run bundle exec cucumber-queue $SCRATCH --require test/samples/features/step_definitions
+  assert_status 0
+  refute_output_matches "Feature: Foobar$"
 }

--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -1,7 +1,15 @@
 load "testlib"
 
+SCRATCH=tmp/minitest5-tests
+
 setup() {
   require_gem "minitest" ">= 5.0"
+  rm -rf $SCRATCH
+  mkdir -p $SCRATCH
+}
+
+teardown() {
+  rm -rf $SCRATCH
 }
 
 @test "minitest-queue (minitest5) succeeds when all tests pass" {
@@ -54,9 +62,50 @@ setup() {
   assert_output_contains "MiniTestFailure#test_fail"
 }
 
-@test "fails when TEST_QUEUE_WORKERS is <= 0" {
+@test "minitest-queue fails when TEST_QUEUE_WORKERS is <= 0" {
   export TEST_QUEUE_WORKERS=0
   run bundle exec minitest-queue ./test/samples/sample_minitest5.rb
   assert_status 1
   assert_output_contains "Worker count (0) must be greater than 0"
+}
+
+@test "minitest-queue fails when given a missing test file" {
+  run bundle exec minitest-queue ./test/samples/does_not_exist.rb
+  assert_status 1
+  assert_output_contains "Aborting: Discovering suites failed"
+}
+
+@test "minitest-queue fails when given a malformed test file" {
+  [ -f README.md ]
+  run bundle exec minitest-queue README.md
+  assert_status 1
+  assert_output_contains "\`require': cannot load such file"
+}
+
+@test "minitest-queue handles test file being deleted" {
+  cp test/samples/sample_mini{test5,spec}.rb $SCRATCH
+
+  run bundle exec minitest-queue $SCRATCH/*
+  assert_status 0
+  assert_output_contains "Meme::when asked about blending possibilities"
+
+  rm $SCRATCH/sample_minispec.rb
+
+  run bundle exec minitest-queue $SCRATCH/*
+  assert_status 0
+  refute_output_contains "Meme::when asked about blending possibilities"
+}
+
+@test "minitest-queue handles suites changing inside a file" {
+  cp test/samples/sample_minispec.rb $SCRATCH
+
+  run bundle exec minitest-queue $SCRATCH/sample_minispec.rb
+  assert_status 0
+  assert_output_contains "Meme::when asked about blending possibilities"
+
+  sed -i'' -e 's/Meme/Meme2/g' $SCRATCH/sample_minispec.rb
+
+  run bundle exec minitest-queue $SCRATCH/sample_minispec.rb
+  assert_status 0
+  assert_output_contains "Meme2::when asked about blending possibilities"
 }

--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -79,7 +79,7 @@ teardown() {
   [ -f README.md ]
   run bundle exec minitest-queue README.md
   assert_status 1
-  assert_output_contains "\`require': cannot load such file"
+  assert_output_contains "Aborting: Discovering suites failed"
 }
 
 @test "minitest-queue handles test file being deleted" {

--- a/test/testlib.bash
+++ b/test/testlib.bash
@@ -34,6 +34,16 @@ assert_status() {
   return 0
 }
 
+refute_status() {
+  expected=$1
+  [ "$status" -ne "$expected" ] || {
+    echo "Expected status not to be $expected. Full output:"
+    echo "$output"
+    return 1
+  }
+  return 0
+}
+
 assert_output_contains() {
   echo "$output" | fgrep --quiet "$@" || {
     echo "Expected to find \"$@\" in:"


### PR DESCRIPTION
For large test suites, having the master require all test files can introduce tens of seconds of latency before any tests start running at all. Since each worker only runs a subset of the tests, it's wasteful to make them all wait until all tests have been loaded.

First, some terminology:

- a "suite" is the unit of work that test-queue parallelizes. (E.g., in Minitest this is a test class. In RSpec this is an ExampleGroup, unless `TEST_QUEUE_SPLIT_GROUPS` is being used.)
- a "suite name" is a string that uniquely identifies a suite, and is stable across multiple processes that each load that suite separately

The master no longer loads any suites. It forks a "suite discovery" process that loads all the suite files specified by the test framework (usually based on command line parameters). The suite discovery process sends `[suite name, path]` pairs back to the master, which adds them to the queue to distribute to the workers. The master also forks off workers immediately, before any suites have been found by the discovery process.

When a worker asks for a suite to run before any have been discovered, the master sends the worker a `WAIT` command, the worker sleeps for a bit, and then it asks again. When a worker gets a `[suite name, path]` pair from the master, it tells the test framework to load the file at that path and return the suite with the given name, then it runs that suite as usual.

The stats file now stores a file path for each suite. This lets the master start handing out suites to the workers while the suite discovery process is still running, so on subsequent builds the startup latency is essentially zero.

Most test-framework-specific behavior is now abstracted behind a TestFramework class.

/cc @bhuga @tmm1