### PR TITLE
Always respect TEST_QUEUE_FORCE ordering

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -257,7 +257,14 @@ module TestQueue
     end
 
     def discover_suites
+      # Remote masters don't discover suites; the central master does and
+      # distributes them to remote masters.
       return if relay?
+
+      # No need to discover suites if all whitelisted suites are already
+      # queued.
+      return if @whitelist.any? && @awaited_suites.empty?
+
       @discovering_suites_pid = fork do
         terminate = false
         Signal.trap("INT") { terminate = true }

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -262,6 +262,8 @@ module TestQueue
         terminate = false
         Signal.trap("INT") { terminate = true }
 
+        $0 = "test-queue suite discovery process"
+
         @test_framework.all_suite_files.each do |path|
           @test_framework.suites_from_file(path).each do |suite_name, suite|
             Kernel.exit!(0) if terminate

--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -37,6 +37,36 @@ teardown() {
   refute_output_contains "MiniTestSleep9"
 }
 
+assert_test_queue_force_ordering() {
+  run bundle exec minitest-queue "$@"
+  assert_status 0
+  assert_output_contains "Starting test-queue master"
+
+  # Turn the list of suites that were run into a comma-separated list. Input
+  # looks like:
+  #     SuiteName: .  <0.001>
+  actual_tests=$(echo "$output" | \
+                 egrep '^    .*: \.+  <' | \
+                 sed -E -e 's/^    (.*): \.+.*/\1/' | \
+                 tr '\n' ',' | \
+                 sed -e 's/,$//')
+  assert_equal "$TEST_QUEUE_FORCE" "$actual_tests"
+}
+
+@test "TEST_QUEUE_FORCE ensures test ordering" {
+  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="Meme::when asked about cheeseburgers,MiniTestEqual"
+
+  # Without stats file
+  rm -f .test_queue_stats
+  assert_test_queue_force_ordering ./test/samples/sample_minitest5.rb ./test/samples/sample_minispec.rb
+  rm -f .test_queue_stats
+  assert_test_queue_force_ordering ./test/samples/sample_minispec.rb ./test/samples/sample_minitest5.rb
+
+  # With stats file
+  assert_test_queue_force_ordering ./test/samples/sample_minitest5.rb ./test/samples/sample_minispec.rb
+  assert_test_queue_force_ordering ./test/samples/sample_minispec.rb ./test/samples/sample_minitest5.rb
+}
+
 @test "multi-master succeeds when all tests pass" {
   export TEST_QUEUE_RELAY_TOKEN=$(date | cksum | cut -d' ' -f1)
   TEST_QUEUE_RELAY=0.0.0.0:12345 bundle exec minitest-queue ./test/samples/sample_minitest5.rb || true &

--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -67,6 +67,13 @@ assert_test_queue_force_ordering() {
   assert_test_queue_force_ordering ./test/samples/sample_minispec.rb ./test/samples/sample_minitest5.rb
 }
 
+@test "minitest-queue fails if TEST_QUEUE_FORCE specifies nonexistent tests" {
+  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MiniTestSleep21,DoesNotExist"
+  run bundle exec minitest-queue ./test/samples/*_minitest5.rb
+  assert_status 1
+  assert_output_contains "Failed to discover DoesNotExist specified in TEST_QUEUE_FORCE"
+}
+
 @test "multi-master succeeds when all tests pass" {
   export TEST_QUEUE_RELAY_TOKEN=$(date | cksum | cut -d' ' -f1)
   TEST_QUEUE_RELAY=0.0.0.0:12345 bundle exec minitest-queue ./test/samples/sample_minitest5.rb || true &

--- a/test/testlib.bash
+++ b/test/testlib.bash
@@ -79,3 +79,11 @@ refute_output_matches() {
   }
   return 0
 }
+
+assert_equal() {
+  [ "$1" = "$2" ] || {
+    echo "Expected \"$1\" to equal \"$2\""
+    return 1
+  }
+  return 0
+}


### PR DESCRIPTION
`TEST_QUEUE_FORCE` is supposed to specify both the list of suites to run and the order they are run in. Currently, order is only guaranteed if `.test_queue_stats` contains all the specified suites. This PR will fix this (but right now just adds a failing test to demonstrate the bug).

/cc @bhuga