### PR TITLE
Fix the Shared examples beging deleting.

### DIFF
--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -46,7 +46,7 @@ module TestQueue
       end
 
       def suites_from_file(path)
-        ::RSpec.world.reset
+        ::RSpec.world.example_groups.clear
         load path
         split_groups(::RSpec.world.example_groups).map { |example_or_group|
           name = if example_or_group.respond_to?(:id)

--- a/test/rspec.bats
+++ b/test/rspec.bats
@@ -36,3 +36,11 @@ setup() {
   assert_output_contains "2 examples, 0 failures"
   assert_output_contains "0 examples, 0 failures"
 }
+
+@test "Use to Shared Exsamples." {
+  run bundle exec rspec-queue ./test/samples/sample_use_shared_example1_spec.rb \
+                              ./test/samples/sample_use_shared_example2_spec.rb
+  assert_status 0
+
+}
+

--- a/test/samples/sample_rspec_helper.rb
+++ b/test/samples/sample_rspec_helper.rb
@@ -1,0 +1,1 @@
+require_relative 'sample_shared_examples_for_spec'

--- a/test/samples/sample_shared_examples_for_spec.rb
+++ b/test/samples/sample_shared_examples_for_spec.rb
@@ -1,0 +1,5 @@
+
+shared_examples_for 'Sample Example' do
+  it { should eq 5 }
+end
+

--- a/test/samples/sample_use_shared_example1_spec.rb
+++ b/test/samples/sample_use_shared_example1_spec.rb
@@ -1,0 +1,8 @@
+require 'rspec'
+require_relative 'sample_rspec_helper'
+
+describe 'Use SharedExcaplesFor test_1' do
+  subject { 5 }
+  it_behaves_like 'Sample Example'
+end
+

--- a/test/samples/sample_use_shared_example2_spec.rb
+++ b/test/samples/sample_use_shared_example2_spec.rb
@@ -1,0 +1,8 @@
+require 'rspec'
+require_relative 'sample_rspec_helper'
+
+describe 'Use SharedExcaplesFor test_2' do
+  subject { 5 }
+  it_behaves_like 'Sample Example'
+end
+


### PR DESCRIPTION
Raise exception,  using the `require` via `shared_examples_for`.

## Before correction.
Test:
```
@test "Use to Shared Exsamples." {
  run bundle exec rspec-queue ./test/samples/sample_use_shared_example1_spec.rb \
                              ./test/samples/sample_use_shared_example2_spec.rb
  assert_status 0
}
```

Exception:
```
 ✗ Use to Shared Exsamples.
   (from function `assert_status' in file test/testlib.bash, line 32,
    in test file test/rspec.bats, line 43)
     `assert_status 0' failed
   Expected status to be 0 but was 1. Full output:
   Starting test-queue master (/tmp/test_queue_88633_70198842389740.sock)
   /Users/takeshinoda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.2.3/lib/rspec/core/example_group.rb:347:in `find_and_eval_shared': Could not find shared examples "Sample Example" (ArgumentError)
        from /Users/takeshinoda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.2.3/lib/rspec/core/example_group.rb:308:in `block (2 levels) in define_nested_shared_group_method'
 ...
```

Codes:
```
$ cat sample_use_shared_example1_spec.rb
require 'rspec'
require_relative 'sample_rspec_helper'

describe 'Use SharedExcaplesFor test_1' do
  subject { 5 }
  it_behaves_like 'Sample Example'
end
```
```
$ cat sample_use_shared_example2_spec.rb
require 'rspec'
require_relative 'sample_rspec_helper'

describe 'Use SharedExcaplesFor test_2' do
  subject { 5 }
  it_behaves_like 'Sample Example'
end
```

Shared examples for:
```
 $ cat sample_shared_examples_for_spec.rb

shared_examples_for 'Sample Example' do
  it { should eq 5 }
end
```