### PR TITLE
Replace File.exists? with File.exist? for deprecation warning.

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -72,7 +72,7 @@ module TestQueue
       @concurrency =
         concurrency ||
         (ENV['TEST_QUEUE_WORKERS'] && ENV['TEST_QUEUE_WORKERS'].to_i) ||
-        if File.exists?('/proc/cpuinfo')
+        if File.exist?('/proc/cpuinfo')
           File.read('/proc/cpuinfo').split("\n").grep(/processor/).size
         elsif RUBY_PLATFORM =~ /darwin/
           `/usr/sbin/sysctl -n hw.activecpu`.to_i
@@ -201,7 +201,7 @@ module TestQueue
           @socket = "#$1:#$2"
           @server = TCPServer.new(address, port)
         else
-          FileUtils.rm(@socket) if File.exists?(@socket)
+          FileUtils.rm(@socket) if File.exist?(@socket)
           @server = UNIXServer.new(@socket)
         end
       end
@@ -393,12 +393,12 @@ module TestQueue
     end
 
     def collect_worker_data(worker)
-      if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_output")
+      if File.exist?(file = "/tmp/test_queue_worker_#{worker.pid}_output")
         worker.output = IO.binread(file)
         FileUtils.rm(file)
       end
 
-      if File.exists?(file = "/tmp/test_queue_worker_#{worker.pid}_suites")
+      if File.exist?(file = "/tmp/test_queue_worker_#{worker.pid}_suites")
         worker.suites.replace(Marshal.load(IO.binread(file)))
         FileUtils.rm(file)
       end


### PR DESCRIPTION
Ruby 2.3.1 says `File.exists?` is deprecated, and use `File.exist?` instead as follows, and `File.exist?` has also existed since Ruby 1.8.x, or before.

```
ruby/2.3.0/gems/test-queue-0.4.0/lib/test_queue/runner.rb:396: warning: File.exists? is a deprecated name, use File.exist? instead
ruby/2.3.0/gems/test-queue-0.4.0/lib/test_queue/runner.rb:401: warning: File.exists? is a deprecated name, use File.exist? instead
```