### PR TITLE
Suppress @aborting is not initialized warning.

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -108,6 +108,8 @@ module TestQueue
       end
 
       @exit_when_done = true
+
+      @aborting = false
     end
 
     # Run the tests.


### PR DESCRIPTION
Ruby 2.3.1 says @aborting is not initialized as follows, so I've fixed it.

```
ruby/2.3.0/gems/test-queue-0.4.0/lib/test_queue/runner.rb:408: warning: instance variable @aborting not initialized
```