### PR TITLE
Always send the token when communicating with the master

### DIFF
--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -80,7 +80,8 @@ module TestQueue
         else
           UNIXSocket.new(@sock)
         end
-      sock.puts("TOKEN=#{@run_token} #{cmd}")
+      sock.puts("TOKEN=#{@run_token}")
+      sock.puts(cmd)
       sock
     rescue Errno::EPIPE
       nil

--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -2,7 +2,7 @@ module TestQueue
   class Iterator
     attr_reader :sock
 
-    def initialize(test_framework, sock, filter=nil, early_failure_limit: nil)
+    def initialize(test_framework, sock, filter=nil, run_token:, early_failure_limit: nil)
       @test_framework = test_framework
       @done = false
       @suite_stats = []
@@ -14,6 +14,7 @@ module TestQueue
       end
       @failures = 0
       @early_failure_limit = early_failure_limit
+      @run_token = run_token
     end
 
     def each
@@ -79,7 +80,7 @@ module TestQueue
         else
           UNIXSocket.new(@sock)
         end
-      sock.puts(cmd)
+      sock.puts("TOKEN=#{@run_token} #{cmd}")
       sock
     rescue Errno::EPIPE
       nil

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -31,7 +31,7 @@ module TestQueue
     attr_accessor :concurrency, :exit_when_done
     attr_reader :stats
 
-    TOKEN_REGEX = /^TOKEN=(\w+)/
+    TOKEN_REGEX = /^TOKEN=(\w+) /
 
     def initialize(test_framework, concurrency=nil, socket=nil, relay=nil)
       @test_framework = test_framework
@@ -445,7 +445,7 @@ module TestQueue
             next
           end
 
-          cmd = cmd.gsub(TOKEN_REGEX, "").strip
+          cmd = cmd.gsub(TOKEN_REGEX, "")
 
           case cmd
           when /^POP/

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -450,7 +450,7 @@ module TestQueue
           cmd = cmd.gsub(TOKEN_REGEX, "").strip
 
           case cmd
-          when /POP/
+          when /^POP/
             # If we have a slave from a different test run, don't respond, and it will consider the test run done.
             if awaiting_suites?
               sock.write(Marshal.dump("WAIT"))
@@ -458,7 +458,7 @@ module TestQueue
               data = Marshal.dump(obj)
               sock.write(data)
             end
-          when /SLAVE (\d+) ([\w\.-]+) (?: (.+))?/
+          when /^SLAVE (\d+) ([\w\.-]+) (?: (.+))?/
             num = $1.to_i
             slave = $2
             slave_message = $3
@@ -469,15 +469,15 @@ module TestQueue
             message = "*** #{num} workers connected from #{slave} after #{Time.now-@start_time}s"
             message << " " + slave_message if slave_message
             STDERR.puts message
-          when /WORKER (\d+)/
+          when /^WORKER (\d+)/
             data = sock.read($1.to_i)
             worker = Marshal.load(data)
             worker_completed(worker)
             remote_workers -= 1
-          when /NEW SUITE (.+)/
+          when /^NEW SUITE (.+)/
             suite_name, path = Marshal.load($1)
             enqueue_discovered_suite(suite_name, path)
-          when /KABOOM/
+          when /^KABOOM/
             # worker reporting an abnormal number of test failures;
             # stop everything immediately and report the results.
             break

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -432,15 +432,9 @@ module TestQueue
 
           token = cmd[TOKEN_REGEX, 1]
           # If we have a slave from a different test run, respond with "WRONG RUN", and it will consider the test run done.
-          case token
-          # No special handling if the token is valid
-          when @run_token
-          when nil
-            STDERR.puts "*** Worker sent no token to master for run #{@run_token}; ignoring."
-            sock.write("WRONG RUN\n")
-            next
-          else
-            STDERR.puts "*** Worker from run #{run_token} connected to master for run #{@run_token}; ignoring."
+          if token != @run_token
+            message = token.nil? ? "Worker sent no token to master" : "Worker from run #{run_token} connected to master"
+            STDERR.puts "*** #{message} for run #{@run_token}; ignoring."
             sock.write("WRONG RUN\n")
             next
           end

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -447,8 +447,10 @@ module TestQueue
             next
           end
 
+          cmd = cmd.gsub(TOKEN_REGEX, "").strip
+
           case cmd
-          when /^TOKEN=\w+ POP/
+          when /POP/
             # If we have a slave from a different test run, don't respond, and it will consider the test run done.
             if awaiting_suites?
               sock.write(Marshal.dump("WAIT"))
@@ -456,7 +458,7 @@ module TestQueue
               data = Marshal.dump(obj)
               sock.write(data)
             end
-          when /^TOKEN=\w+ SLAVE (\d+) ([\w\.-]+) (?: (.+))?/
+          when /SLAVE (\d+) ([\w\.-]+) (?: (.+))?/
             num = $1.to_i
             slave = $2
             slave_message = $3
@@ -467,15 +469,15 @@ module TestQueue
             message = "*** #{num} workers connected from #{slave} after #{Time.now-@start_time}s"
             message << " " + slave_message if slave_message
             STDERR.puts message
-          when /^TOKEN=\w+ WORKER (\d+)/
+          when /WORKER (\d+)/
             data = sock.read($1.to_i)
             worker = Marshal.load(data)
             worker_completed(worker)
             remote_workers -= 1
-          when /^TOKEN=\w+ NEW SUITE (.+)/
+          when /NEW SUITE (.+)/
             suite_name, path = Marshal.load($1)
             enqueue_discovered_suite(suite_name, path)
-          when /^TOKEN=\w+ KABOOM/
+          when /KABOOM/
             # worker reporting an abnormal number of test failures;
             # stop everything immediately and report the results.
             break

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -436,7 +436,7 @@ module TestQueue
           token = token[TOKEN_REGEX, 1]
           # If we have a slave from a different test run, respond with "WRONG RUN", and it will consider the test run done.
           if token != @run_token
-            message = token.nil? ? "Worker sent no token to master" : "Worker from run #{run_token} connected to master"
+            message = token.nil? ? "Worker sent no token to master" : "Worker from run #{token} connected to master"
             STDERR.puts "*** #{message} for run #{@run_token}; ignoring."
             sock.write("WRONG RUN\n")
             next

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -31,6 +31,8 @@ module TestQueue
     attr_accessor :concurrency, :exit_when_done
     attr_reader :stats
 
+    TOKEN_REGEX = /^TOKEN=(\w+)/
+
     def initialize(test_framework, concurrency=nil, socket=nil, relay=nil)
       @test_framework = test_framework
       @stats = Stats.new(stats_file)
@@ -428,9 +430,9 @@ module TestQueue
           sock = @server.accept
           cmd = sock.gets.strip
 
-          cmd =~ /^TOKEN=(\w+)/
+          token = cmd[TOKEN_REGEX, 1]
           # If we have a slave from a different test run, don't respond, and it will consider the test run done.
-          case $1
+          case token
           # No special handling if the token is valid
           when @run_token
           when nil

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -438,12 +438,10 @@ module TestQueue
           when nil
             STDERR.puts "*** Worker sent no token to master for run #{@run_token}; ignoring."
             sock.write("WRONG RUN\n")
-            File.open("/tmp/errors.log", "a") {|f| f.puts "WRONG RUN - nil token"}
             next
           else
             STDERR.puts "*** Worker from run #{run_token} connected to master for run #{@run_token}; ignoring."
             sock.write("WRONG RUN\n")
-            File.open("/tmp/errors.log", "a") {|f| f.puts "WRONG RUN - wrong token"}
             next
           end
 

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -431,7 +431,7 @@ module TestQueue
           cmd = sock.gets.strip
 
           token = cmd[TOKEN_REGEX, 1]
-          # If we have a slave from a different test run, don't respond, and it will consider the test run done.
+          # If we have a slave from a different test run, respond with "WRONG RUN", and it will consider the test run done.
           case token
           # No special handling if the token is valid
           when @run_token


### PR DESCRIPTION
Currently, tokens are only verified when a slave first connects to master, not on every communication. In a scenario where the master process aborts a build, but the slave processes haven't been reaped, those slaves can end up communicating with a new master when a new build is commenced on the same host. This moves the run token to the start of the message and sends/checks it on every communication.

This is a pretty minimal change, and I think it would be good to refactor `distribute_queue` a little, but it should solve the immediate issue.

cc @aroben, @bhuga 