### PR TITLE
Fix SLAVE regex, log unrecognized commands

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -474,6 +474,8 @@ module TestQueue
             # worker reporting an abnormal number of test failures;
             # stop everything immediately and report the results.
             break
+          else
+            STDERR.puts("Ignoring unrecognized command: \"#{cmd}\"")
           end
           sock.close
         end

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -451,7 +451,7 @@ module TestQueue
               data = Marshal.dump(obj)
               sock.write(data)
             end
-          when /^SLAVE (\d+) ([\w\.-]+) (?: (.+))?/
+          when /^SLAVE (\d+) ([\w\.-]+)(?: (.+))?/
             num = $1.to_i
             slave = $2
             slave_message = $3

--- a/test/sleepy_runner.rb
+++ b/test/sleepy_runner.rb
@@ -1,0 +1,14 @@
+require 'test_queue'
+require 'test_queue/runner/minitest'
+
+class SleepyTestRunner < TestQueue::Runner::MiniTest
+  def after_fork(num)
+    if ENV['SLEEP_AS_RELAY'] && relay? 
+      sleep 5
+    elsif ENV['SLEEP_AS_MASTER'] && !relay?
+      sleep 5
+    end
+  end
+end
+
+SleepyTestRunner.new.execute


### PR DESCRIPTION
A stray space in the `/^SLAVE` regex meant that certain commands were being ignored. I've also added logging when a command doesn't match any of the regexes and will be ignored, though I think there's an argument to be made for replying with a more explicit error to the worker.

cc @aroben