### PR TITLE
Swap order of starting up RELAY/SOCKET processes in multi-master tests

### DIFF
--- a/test/sleepy_runner.rb
+++ b/test/sleepy_runner.rb
@@ -1,0 +1,14 @@
+require 'test_queue'
+require 'test_queue/runner/minitest'
+
+class SleepyTestRunner < TestQueue::Runner::MiniTest
+  def after_fork(num)
+    if ENV['SLEEP_AS_RELAY'] && relay? 
+      sleep 5
+    elsif ENV['SLEEP_AS_MASTER'] && !relay?
+      sleep 5
+    end
+  end
+end
+
+SleepyTestRunner.new.execute


### PR DESCRIPTION
The tests should fail here since they're missing the fix from #65. cc @aroben 