### PR TITLE
WIP Report unexpected tests, discovered-but-unrun tests

### DIFF
--- a/lib/test_queue/iterator.rb
+++ b/lib/test_queue/iterator.rb
@@ -30,7 +30,7 @@ module TestQueue
           connect_to_master("KABOOM")
           break
         else
-          client = connect_to_master('POP')
+          client = connect_to_master("POP #{Socket.gethostname} #{Process.pid}")
         end
         break if client.nil?
         _r, _w, e = IO.select([client], nil, [client], nil)

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -338,10 +338,10 @@ module TestQueue
         return
       end
 
+      @discovered_suites << [suite_name, path]
+
       if @original_queue.include?([suite_name, path])
         # This suite was already added to the queue some other way.
-        # We still want to track it in the list of discovered suites though.
-        @discovered_suites << [suite_name, path]
         @awaited_suites.delete(suite_name)
         return
       end
@@ -350,7 +350,6 @@ module TestQueue
       # the front of the queue. It's better to run a fast suite early than to
       # run a slow suite late.
       @queue.unshift [suite_name, path]
-      @discovered_suites << [suite_name, path]
 
       if @awaited_suites.delete?(suite_name) && @awaited_suites.empty?
         # We've found all the whitelisted suites. Sort the queue to match the

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -212,7 +212,7 @@ module TestQueue
       summarize
 
       estatus = @completed.inject(0){ |s, worker| s + worker.status.exitstatus }
-      estatus += 1 unless @discovered_suites.empty? && misrun_suites.empty? && unassigned_suites.empty?
+      estatus += 1 if !relay? unless @discovered_suites.empty? && misrun_suites.empty? && unassigned_suites.empty?
       estatus = 255 if estatus > 255
       estatus
     end

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -168,23 +168,25 @@ module TestQueue
         puts @failures
       end
 
-      skipped_suites = @discovered_suites - run_suites
-      unexpected_suites = run_suites - @discovered_suites
-      unless skipped_suites.empty?
-        puts
-        puts "The following suites were discovered but were not run:"
-        puts
+      if !relay?
+        skipped_suites = @discovered_suites - run_suites
+        unexpected_suites = run_suites - @discovered_suites
+        unless skipped_suites.empty?
+          puts
+          puts "The following suites were discovered but were not run:"
+          puts
 
-        skipped_suites.sort.each do |suite_name, path|
-          puts "#{suite_name} - #{path}"
+          skipped_suites.sort.each do |suite_name, path|
+            puts "#{suite_name} - #{path}"
+          end
         end
-      end
-      unless unexpected_suites.empty?
-        puts
-        puts "The following suites were not discovered but were run anyway:"
-        puts
-        unexpected_suites.sort.each do |suite_name, path|
-          puts "#{suite_name} - #{path}"
+        unless unexpected_suites.empty?
+          puts
+          puts "The following suites were not discovered but were run anyway:"
+          puts
+          unexpected_suites.sort.each do |suite_name, path|
+            puts "#{suite_name} - #{path}"
+          end
         end
       end
 

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -65,7 +65,7 @@ module TestQueue
         @queue.sort_by! { |suite_name, path| @whitelist.index(suite_name) }
       end
 
-      @awaited_suites = Set.new(@whitelist - @queue.map(&:first))
+      @awaited_suites = Set.new(@whitelist)
       @original_queue = Set.new(@queue).freeze
 
       @workers = {}
@@ -340,6 +340,7 @@ module TestQueue
         # This suite was already added to the queue some other way.
         # We still want to track it in the list of discovered suites though.
         @discovered_suites << [suite_name, path]
+        @awaited_suites.delete(suite_name)
         return
       end
 


### PR DESCRIPTION
This is adapted from a couple of commits in @aroben's suite-files branch. This is definitely still broken, opening a PR to compare cibuild results to my local runs.

1. ~~In the "rename" test, the queue passed when `Runner` is instantiated at the beginning of the second test run contains both the old and new suite names, both associated with the same path. The old suite names are flagged as discovered-but-not-run.~~

2. ~~A couple of the rspec examples are broken, possibly due to example splitting.~~