### PR TITLE
Stats: rescue ArgumentError when loading stats file

### DIFF
--- a/lib/test_queue/stats.rb
+++ b/lib/test_queue/stats.rb
@@ -74,7 +74,7 @@ module TestQueue
     def load
       data = begin
                File.open(@path, "rb") { |f| Marshal.load(f) }
-             rescue Errno::ENOENT, EOFError, TypeError
+             rescue Errno::ENOENT, EOFError, TypeError, ArgumentError
              end
       return unless data && data.is_a?(Hash) && data[:version] == CURRENT_VERSION
       data[:suites].each do |suite_hash|


### PR DESCRIPTION
`Marshal.load` can raise `ArgumentError` when given malformed data; in these cases, we'll want to rescue like with the other error conditions.

cc @aroben 