### PR TITLE
Use an error status instead of nil if we're missing a worker status code

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -146,7 +146,7 @@ module TestQueue
       unassigned_suites = []
       @failures = ''
       @completed.each do |worker|
-        estatus += worker.status.exitstatus
+        estatus += (worker.status.exitstatus || 1)
         @stats.record_suites(worker.suites)
         worker.suites.each do |suite|
           assignment = @assignments.delete([suite.name, suite.path])

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -168,7 +168,7 @@ module TestQueue
 
       summarize
 
-      estatus = @completed.inject(0){ |s, worker| s + worker.status.exitstatus }
+      estatus = @completed.inject(0){ |s, worker| s + (worker.status.exitstatus || 1)}
       estatus = 255 if estatus > 255
       estatus
     end

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -150,7 +150,7 @@ module TestQueue
           worker.suites.size,
           worker.end_time - worker.start_time,
           worker.pid,
-          worker.status.exitstatus,
+          worker.status.exitstatus || 1,
           worker.host && " on #{worker.host.split('.').first}"
         ]
       end

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -144,13 +144,12 @@ module TestQueue
 
         @failures << worker.failure_output if worker.failure_output
 
-        puts "    [%2d] %60s      %4d suites in %.4fs      (pid %d exit %d%s)" % [
+        puts "    [%2d] %60s      %4d suites in %.4fs      (%s %s)" % [
           worker.num,
           worker.summary,
           worker.suites.size,
           worker.end_time - worker.start_time,
-          worker.pid,
-          worker.status.exitstatus || 1,
+          worker.status.to_s,
           worker.host && " on #{worker.host.split('.').first}"
         ]
       end

--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -99,6 +99,13 @@ assert_test_queue_force_ordering() {
   assert_output_contains "MiniTestFailure#test_fail"
 }
 
+@test "recovers from child processes dying in an unorderly way" {
+  export KILL=1
+  run bundle exec minitest-queue ./test/samples/sample_minitest5.rb
+  assert_status 1
+  assert_output_contains "SIGKILL (signal 9)"
+}
+
 @test "minitest-queue fails when TEST_QUEUE_WORKERS is <= 0" {
   export TEST_QUEUE_WORKERS=0
   run bundle exec minitest-queue ./test/samples/sample_minitest5.rb

--- a/test/samples/sample_minitest5.rb
+++ b/test/samples/sample_minitest5.rb
@@ -23,3 +23,11 @@ if ENV["FAIL"]
     end
   end
 end
+
+if ENV["KILL"]
+  class MiniTestKilledFailure < MiniTest::Test
+    def test_kill
+      Process.kill(9, $$)
+    end
+  end
+end


### PR DESCRIPTION
Workers missing an exit status are an error. This can happen if a worker's process is killed out-of-band. Currently, summarize will explode on the `%` call if any of these values are nil. 

This doesn't seem too tough to write a test for, but I'm not sure where to put it. Should we copy one of the suites, say minitest5, and have a suite for test-queue features as opposed to end-to-end tests for each test framework?