### PR TITLE
Fix deprecated method at rspec3

### DIFF
--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -47,6 +47,8 @@ module TestQueue
                    example_or_group.id
                  elsif example_or_group.respond_to?(:full_description)
                    example_or_group.full_description
+                 elsif example_or_group.metadata.key?(:full_description)
+                   example_or_group.metadata[:full_description]
                  else
                    example_or_group.metadata[:example_group][:full_description]
                  end

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -10,12 +10,6 @@ else
   fail 'requires rspec version 2 or 3'
 end
 
-class ::RSpec::Core::ExampleGroup
-  def self.failure_count
-    examples.map {|e| e.execution_result[:status] == "failed"}.length
-  end
-end
-
 module TestQueue
   class Runner
     class RSpec < Runner

--- a/lib/test_queue/runner/rspec2.rb
+++ b/lib/test_queue/runner/rspec2.rb
@@ -1,3 +1,9 @@
+class ::RSpec::Core::ExampleGroup
+  def self.failure_count
+    examples.map {|e| e.execution_result[:status] == "failed"}.length
+  end
+end
+
 module RSpec::Core
   class QueueRunner < CommandLine
     def initialize

--- a/lib/test_queue/runner/rspec3.rb
+++ b/lib/test_queue/runner/rspec3.rb
@@ -1,3 +1,9 @@
+class ::RSpec::Core::ExampleGroup
+  def self.failure_count
+    examples.map {|e| e.execution_result.status == "failed"}.length
+  end
+end
+
 module RSpec::Core
   # RSpec 3.2 introduced:
   unless Configuration.method_defined?(:with_suite_hooks)


### PR DESCRIPTION
Hi. 

When use rspec3, show warning message such as followings. Fix it.

```
Treating `metadata[:execution_result]` as a hash is deprecated. Use the attributes methods to access thedata instead. Called from /Users/w1mvy/src/github.com/w1mvy/test-queue/lib/test_queue/runner/rspec.rb:15:in `block in failure_count'.
```

Show this warning, when use  rspec option `config.raise_errors_for_deprecations!`.

```
The `:example_group` key in an example group's metadata hash is deprecated. Use the example group's hashdirectly for the computed keys and `:parent_example_group` to access the parent example group metadata instead. Called from /Users/w1mvy/src/github.com/w1mvy/test-queue/lib/test_queue/runner/rspec.rb:53:in `block in suites_from_file'.
```