### PR TITLE
Fix test queue resultes for Minitest 5

### DIFF
--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -28,14 +28,28 @@ module MiniTest
     def _synchronize; Test.io_lock.synchronize { yield }; end
   end
 
-  class ProgressReporter
+  class SummaryReporter
     # Override original method to make test-queue specific output
-    def record result
-      io.print '    '
-      io.print result.class
-      io.print ': '
-      io.print result.result_code
-      io.puts("  <%.3f>" % result.time)
+    def report
+      aggregate = results.group_by { |r| r.class }
+      aggregate.each do |class_name, results|
+        io.print '    '
+        io.print class_name
+        io.print ': '
+        result_codes = []
+        time = 0
+
+        results.each do |result|
+          result_codes << result.result_code
+          time += result.time
+        end
+        io.print result_codes.join
+        io.print "  <%.3f>" % time
+      end
+    end
+
+    def record(result)
+      results << result
     end
   end
 


### PR DESCRIPTION
Hey 👋  I'm not sure if you're interested in maintaining this but test-queue output doesn't work right with minitest 5 so I fixed it 😄  

As noted in issue #22 Minitest 5 changed the results so that outputting
the test queue results in `record` causes the suite to be output as
such:

```
SuiteName: .
SuiteName: .
SuiteName: .
```

The output should instead look like:

```
SuiteName: ...
```

This commits collects the results in `record` and then groups those
results by class so it can iterate through each grouped class and
properly report pass/skip/fail via test queue output.

We need to use the SummaryReporter here instead of the ProgressReporter
so we have access to `results` in `record`.

Closes #22 
