### PR TITLE
Fix re-run command argument missing, when rspec 3.2

### DIFF
--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -36,7 +36,14 @@ module TestQueue
         options.parse_options if options.respond_to?(:parse_options)
         options.configure(::RSpec.configuration)
 
-        ::RSpec.configuration.files_to_run.uniq
+        files = ::RSpec.configuration.files_to_run.uniq
+        # Save spec file path to print re-run command with spec file path
+        if ::RSpec.configuration.respond_to?(:loaded_spec_files)
+          files.each do |f|
+            ::RSpec.configuration.loaded_spec_files << File.expand_path(f)
+          end
+        end
+        files
       end
 
       def suites_from_file(path)

--- a/test/rspec.bats
+++ b/test/rspec.bats
@@ -16,6 +16,7 @@ setup() {
   assert_status 1
   assert_output_contains "1) RSpecFailure fails"
   assert_output_contains "Failure/Error: expect(:foo).to eq :bar"
+  assert_output_contains "rspec ./test/samples/sample_spec.rb:21"
 }
 
 @test "TEST_QUEUE_SPLIT_GROUPS splits splittable groups" {


### PR DESCRIPTION
rspec-queue with rspec < 3.2 prints command to re-run failed example. (This is expected behavior)

```
$ FAIL=1 BUNDLE_GEMFILE=Gemfile-rspec3-1 bundle exec rspec-queue spec/stats_spec.rb test/samples/sample_spec.rb | grep -E "^rspec"
rspec test/samples/sample_spec.rb:21 # RSpecFailure fails
```

But, rspec-queue with rspec 3.2 prints command that misses arguments.

```
$ FAIL=1 BUNDLE_GEMFILE=Gemfile-rspec3-2 bundle exec rspec-queue spec/stats_spec.rb test/samples/sample_spec.rb | grep -E "^rspec"
rspec  # RSpecFailure fails
```

The argument is generated by `RSpec::Example#rerun_argument`.

But, in RSpec 3.2, `RSpec::Example#rerun_argument` returns `nil` when the spec file is not in `RSpec.configuration.loaded_spec_files`.

I wrote some lines to add spec files to `RSpec.configuration.loaded_spec_files`.
