### PR TITLE
GitHub is https by default

### DIFF
--- a/test-queue.gemspec
+++ b/test-queue.gemspec
@@ -4,7 +4,7 @@ spec = Gem::Specification.new do |s|
   s.summary = 'parallel test runner'
   s.description = 'minitest/rspec parallel test runner for CI environments'
 
-  s.homepage = "http://github.com/tmm1/test-queue"
+  s.homepage = "https://github.com/tmm1/test-queue"
 
   s.authors = ["Aman Gupta"]
   s.email = "ruby@tmm1.net"


### PR DESCRIPTION
This reduces unneeded redirection from `http://...` to `https://...` when someone visits this gem's homepage via https://rubygems.org/gems/test-queue.