### PR TITLE
Remove `Gem::Specification#has_rdoc=` from gemspec

### DIFF
--- a/test-queue.gemspec
+++ b/test-queue.gemspec
@@ -10,7 +10,6 @@ spec = Gem::Specification.new do |s|
   s.email = "ruby@tmm1.net"
   s.license = 'MIT'
 
-  s.has_rdoc = false
   s.bindir = 'bin'
   s.executables << 'rspec-queue'
   s.executables << 'minitest-queue'


### PR DESCRIPTION
`Gem::Specification#has_rdoc=` is a deprecated method.
This PR removes `Gem::Specification#has_rdoc=` from gemspec.

```console
% ruby -v
ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin17]
% gem -v
3.0.4
% cd path/to/test-queue
% bundle install
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It
will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from
/Users/koic/src/github.com/tmm1/test-queue/test-queue.gemspec:13.
Fetching gem metadata from https://rubygems.org/..........

(snip)
```