### PR TITLE
Suppress a Ruby's warning

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -37,6 +37,7 @@ module TestQueue
       @test_framework = test_framework
       @stats = Stats.new(stats_file)
 
+      @early_failure_limit = nil
       if ENV['TEST_QUEUE_EARLY_FAILURE_LIMIT']
         begin
           @early_failure_limit = Integer(ENV['TEST_QUEUE_EARLY_FAILURE_LIMIT'])


### PR DESCRIPTION
This PR suppresses the following Ruby's warning.

```console
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/test-queue-0.4.2/lib/test_queue/runner.rb:299:
warning: instance variable @early_failure_limit not initialized
```