### PR TITLE
Prevent a breaking change when using deprecated env var

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -101,7 +101,12 @@ module TestQueue
         relay ||
         ENV['TEST_QUEUE_RELAY']
 
-      @remote_master_message = ENV["TEST_QUEUE_REMOTE_MASTER_MESSAGE"] if ENV.has_key?("TEST_QUEUE_REMOTE_MASTER_MESSAGE")
+      @remote_master_message = if ENV.has_key?("TEST_QUEUE_REMOTE_MASTER_MESSAGE")
+                                 ENV["TEST_QUEUE_REMOTE_MASTER_MESSAGE"]
+                               elsif ENV.has_key?("TEST_QUEUE_SLAVE_MESSAGE")
+                                 warn("`TEST_QUEUE_SLAVE_MESSAGE` is deprecated. Use `TEST_QUEUE_REMOTE_MASTER_MESSAGE` instead.")
+                                 ENV["TEST_QUEUE_SLAVE_MESSAGE"]
+                               end
 
       if @relay == @socket
         STDERR.puts "*** Detected TEST_QUEUE_RELAY == TEST_QUEUE_SOCKET. Disabling relay mode."


### PR DESCRIPTION
Follow up https://github.com/tmm1/test-queue/commit/cf65d12.

This PR prevents a breaking change when using deprecated `TEST_QUEUE_SLAVE_MESSAGE` environment variable.
It is user-friendly to provide a warning message instead of a sudden environment variable name change.