### PR TITLE
CI against Ruby 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu]
         # Lowest and Latest version.
-        ruby: ['2.3', '3.1']
+        ruby: ['2.3', '3.0']
 
     steps:
       - name: checkout


### PR DESCRIPTION
This PR dowangrades Ruby version from 3.1 to 3.0 to fix the following build error:
https://github.com/tmm1/test-queue/actions/runs/4354208063/jobs/7609496270