### PR TITLE
Add `matrix.gemfile` to GitHub Actions's job name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   main:
     name: >-
-      ${{ matrix.os }} ${{ matrix.ruby }}
+      ${{ matrix.os }} ${{ matrix.ruby }} ${{ matrix.gemfile }}
     runs-on: ${{ matrix.os }}-latest
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
It makes failed matrices identifiable by job name.