### PR TITLE
Add vendor dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .ruby-version
 Gemfile.lock
 gemfiles/Gemfile-*.lock
+vendor


### PR DESCRIPTION
This PR adds the vendor directory where `script/bootstrap` installs `bats` to .gitignore:

```console
% script/bootstrap
++ dirname script/bootstrap
+ cd script/..
++ pwd
+ ROOT=/Users/koic/src/github.com/tmm1/test-queue
+ rm -rf tmp
+ mkdir tmp
+ mkdir -p vendor/bats
+ curl --silent --location --show-error https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz
+ tar -xz -C tmp
+ tmp/bats-0.4.0/install.sh /Users/koic/src/github.com/tmm1/test-queue/vendor/bats
Installed Bats to /Users/koic/src/github.com/tmm1/test-queue/vendor/bats/bin/bats
% ls vendor
bats
```

This vendor directory is not managed by the repository.