### PR TITLE
Use `require_relative`

### DIFF
--- a/exe/cucumber-queue
+++ b/exe/cucumber-queue
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
 require 'test_queue'
 require 'test_queue/runner/cucumber'
+
 TestQueue::Runner::Cucumber.new.execute

--- a/exe/minitest-queue
+++ b/exe/minitest-queue
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
 require 'test_queue'
 require 'test_queue/runner/minitest'
+
 TestQueue::Runner::MiniTest.new.execute

--- a/exe/rspec-queue
+++ b/exe/rspec-queue
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
 require 'test_queue'
 require 'test_queue/runner/rspec'
+
 TestQueue::Runner::RSpec.new.execute

--- a/exe/testunit-queue
+++ b/exe/testunit-queue
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
 require 'test_queue'
 require 'test_queue/runner/testunit'
+
 TestQueue::Runner::TestUnit.new.execute

--- a/lib/test-queue.rb
+++ b/lib/test-queue.rb
@@ -1,1 +1,1 @@
-require 'test_queue'
+require_relative 'test_queue'

--- a/lib/test_queue.rb
+++ b/lib/test_queue.rb
@@ -4,5 +4,5 @@ if !IO.respond_to?(:binread)
   end
 end
 
-require 'test_queue/iterator'
-require 'test_queue/runner'
+require_relative 'test_queue/iterator'
+require_relative 'test_queue/runner'

--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -2,8 +2,8 @@ require 'set'
 require 'socket'
 require 'fileutils'
 require 'securerandom'
-require 'test_queue/stats'
-require 'test_queue/test_framework'
+require_relative 'stats'
+require_relative 'test_framework'
 
 module TestQueue
   class Worker

--- a/lib/test_queue/runner/minitest.rb
+++ b/lib/test_queue/runner/minitest.rb
@@ -1,9 +1,9 @@
 begin
   require 'minitest'
-  require 'test_queue/runner/minitest5'
+  require_relative '../runner/minitest5'
 rescue LoadError => e
   require 'minitest/unit'
-  require 'test_queue/runner/minitest4'
+  require_relative '../runner/minitest4'
 end
 
 module TestQueue

--- a/lib/test_queue/runner/minitest4.rb
+++ b/lib/test_queue/runner/minitest4.rb
@@ -1,4 +1,4 @@
-require 'test_queue/runner'
+require_relative '../runner'
 require 'set'
 require 'stringio'
 

--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -1,4 +1,4 @@
-require 'test_queue/runner'
+require_relative '../runner'
 
 module MiniTest
   def self.__run reporter, options

--- a/lib/test_queue/runner/puppet_lint.rb
+++ b/lib/test_queue/runner/puppet_lint.rb
@@ -1,4 +1,4 @@
-require 'test_queue'
+require_relative '../../test_queue'
 require 'puppet-lint'
 
 module TestQueue

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -1,4 +1,4 @@
-require 'test_queue/runner'
+require_relative '../runner'
 require 'rspec/core'
 
 case ::RSpec::Core::Version::STRING.to_i

--- a/lib/test_queue/runner/sample.rb
+++ b/lib/test_queue/runner/sample.rb
@@ -1,5 +1,5 @@
-require 'test_queue'
-require 'test_queue/runner'
+require_relative '../../test_queue'
+require_relative '../runner'
 
 module TestQueue
   class Runner

--- a/lib/test_queue/runner/testunit.rb
+++ b/lib/test_queue/runner/testunit.rb
@@ -1,4 +1,4 @@
-require 'test_queue/runner'
+require_relative '../runner'
 
 gem 'test-unit'
 require 'test/unit'

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -1,5 +1,8 @@
 require "fileutils"
 require "tempfile"
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
 require "test_queue/stats"
 
 RSpec.describe TestQueue::Stats do

--- a/test/sleepy_runner.rb
+++ b/test/sleepy_runner.rb
@@ -1,9 +1,11 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
 require 'test_queue'
 require 'test_queue/runner/minitest'
 
 class SleepyTestRunner < TestQueue::Runner::MiniTest
   def after_fork(num)
-    if ENV['SLEEP_AS_RELAY'] && relay? 
+    if ENV['SLEEP_AS_RELAY'] && relay?
       sleep 5
     elsif ENV['SLEEP_AS_MASTER'] && !relay?
       sleep 5


### PR DESCRIPTION
`require_relative` should be used if the file paths are relative to improve a bit of performance. Or add the `lib` directory to `$LOAD_PATH` so that `require` finds it first.