### PR TITLE
Drop Ruby 2.6 and lower support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu]
         # Lowest and Latest version.
-        ruby: ['2.3', '3.0']
+        ruby: ['2.7', '3.0']
 
     steps:
       - name: checkout

--- a/test-queue.gemspec
+++ b/test-queue.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'test-queue'
   s.version = '0.5.0'
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.summary = 'parallel test runner'
   s.description = 'minitest/rspec parallel test runner for CI environments'
 


### PR DESCRIPTION
They have reached EOL and the test-queue wants to move forward without worrying about them. Ruby 2.7 will reach EOL in March 2023, but since it is the last version in the 2.x series, it will be put on hold for a while.