### PR TITLE
Split CI matrix by Bats

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu]
         # Lowest and Latest version.
-        ruby: ['2.7', '3.0']
+        ruby: ['2.7', '3.1']
         entry:
           - { name: cucumber1-3, bats: test/cucumber.bats }
           - { name: cucumber2-4, bats: test/cucumber.bats }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   main:
     name: >-
-      ${{ matrix.os }} ${{ matrix.ruby }}
+      ${{ matrix.ruby }} ${{ matrix.entry.name }}
     runs-on: ${{ matrix.os }}-latest
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
@@ -21,6 +21,14 @@ jobs:
         os: [ubuntu]
         # Lowest and Latest version.
         ruby: ['2.7', '3.0']
+        entry:
+          - { name: cucumber1-3, bats: test/cucumber.bats }
+          - { name: cucumber2-4, bats: test/cucumber.bats }
+          - { name: minitest4, bats: test/minitest4.bats }
+          - { name: minitest5, bats: test/minitest5.bats }
+          - { name: rspec2, bats: test/rspec.bats }
+          - { name: rspec3, bats: test/rspec.bats }
+          - { name: testunit, bats: test/testunit.bats }
 
     steps:
       - name: checkout
@@ -31,6 +39,12 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: install dependencies
-        run: bundle install --jobs 3 --retry 3 && bundle exec appraisal install
+        run: bundle install --jobs 3 --retry 3
+      - name: setup for Bats
+        run: bundle exec rake setup
       - name: spec
-        run: bundle exec appraisal rake
+        run: bundle exec rake spec
+      - name: install dependencies for ${{ matrix.entry.name }}
+        run: bundle exec appraisal ${{ matrix.entry.name }} bundle install --jobs 3 --retry 3
+      - name: test
+        run: bundle exec appraisal ${{ matrix.entry.name }} vendor/bats/bin/bats ${{ matrix.entry.bats }}

--- a/gemfiles/cucumber1_3.gemfile
+++ b/gemfiles/cucumber1_3.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
 gem "rake", "< 11.0"
 gem "rspec", ">= 2.13", "< 4.0"
 gem "cucumber", "~> 1.3.10"

--- a/gemfiles/cucumber2_4.gemfile
+++ b/gemfiles/cucumber2_4.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
 gem "rake", "< 11.0"
 gem "rspec", ">= 2.13", "< 4.0"
 gem "cucumber", "~> 2.4.0"

--- a/gemfiles/minitest4.gemfile
+++ b/gemfiles/minitest4.gemfile
@@ -2,9 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake"
-gem "rspec", ">= 2.13", "< 4.0"
 gem "minitest", "~> 4.7"
 
 gemspec path: "../"

--- a/gemfiles/minitest5.gemfile
+++ b/gemfiles/minitest5.gemfile
@@ -2,9 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake"
-gem "rspec", ">= 2.13", "< 4.0"
 gem "minitest", "5.4.3"
 
 gemspec path: "../"

--- a/gemfiles/rspec2.gemfile
+++ b/gemfiles/rspec2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
 gem "rake", "< 11.0"
 gem "rspec", "~> 2.13.0"
 

--- a/gemfiles/rspec3.gemfile
+++ b/gemfiles/rspec3.gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake"
 gem "rspec", "~> 3.12"
 
 gemspec path: "../"

--- a/gemfiles/testunit.gemfile
+++ b/gemfiles/testunit.gemfile
@@ -2,9 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
-gem "rake"
-gem "rspec", ">= 2.13", "< 4.0"
 gem "test-unit"
 
 gemspec path: "../"


### PR DESCRIPTION
This PR splits CI matrix by Bats. Not all matrices need to be executed all the time. It is enough for Bats per testing framework to run.