### PR TITLE
CI against Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
       ${{ matrix.ruby }} ${{ matrix.entry.name }}
     runs-on: ${{ matrix.os }}-latest
     env:
-      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       TEST_QUEUE_WORKERS: 2
       TEST_QUEUE_VERBOSE: 1
     strategy:
@@ -20,13 +19,12 @@ jobs:
       matrix:
         os: [ubuntu]
         # Lowest and Latest version.
-        ruby: ['2.7', '3.1']
+        ruby: ['2.7', '3.2']
         entry:
-          - { name: cucumber1-3, bats: test/cucumber.bats }
-          - { name: cucumber2-4, bats: test/cucumber.bats }
+          - { name: cucumber1_3, bats: test/cucumber.bats }
+          - { name: cucumber2_4, bats: test/cucumber.bats }
           - { name: minitest4, bats: test/minitest4.bats }
           - { name: minitest5, bats: test/minitest5.bats }
-          - { name: rspec2, bats: test/rspec.bats }
           - { name: rspec3, bats: test/rspec.bats }
           - { name: testunit, bats: test/testunit.bats }
 
@@ -45,6 +43,51 @@ jobs:
       - name: spec
         run: bundle exec rake spec
       - name: install dependencies for ${{ matrix.entry.name }}
-        run: bundle exec appraisal ${{ matrix.entry.name }} bundle install --jobs 3 --retry 3
+        run: BUNDLE_GEMFILE=gemfiles/${{ matrix.entry.name }}.gemfile bundle install --jobs 3 --retry 3
       - name: test
-        run: bundle exec appraisal ${{ matrix.entry.name }} vendor/bats/bin/bats ${{ matrix.entry.bats }}
+        run: BUNDLE_GEMFILE=gemfiles/${{ matrix.entry.name }}.gemfile vendor/bats/bin/bats ${{ matrix.entry.bats }}
+
+  # RSpec 2 doesn't work with Ruby 3.2:
+  #
+  #   /opt/hostedtoolcache/Ruby/3.2.1/x64/lib/ruby/gems/3.2.0/gems/rspec-core-2.99.2/lib/rspec/core/ruby_project.rb:27:
+  #   in `block in find_first_parent_containing': undefined method `exists?' for File:Class (NoMethodError)
+  #
+  #           ascend_until {|path| File.exists?(File.join(path, dir))}
+  #                                    ^^^^^^^^
+  #   Did you mean?  exist?
+  #
+  # Up to Ruby 3.1 is the supported version for RSpec 2.
+  rspec2:
+    name: >-
+      ${{ matrix.ruby }} ${{ matrix.entry.name }}
+    runs-on: ${{ matrix.os }}-latest
+    env:
+      TEST_QUEUE_WORKERS: 2
+      TEST_QUEUE_VERBOSE: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        # Lowest and Latest version.
+        ruby: ['2.7', '3.1']
+        entry:
+          - { name: rspec2, bats: test/rspec.bats }
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: install dependencies
+        run: bundle install --jobs 3 --retry 3
+      - name: setup for Bats
+        run: bundle exec rake setup
+      - name: spec
+        run: bundle exec rake spec
+      - name: install dependencies for ${{ matrix.entry.name }}
+        run: BUNDLE_GEMFILE=gemfiles/${{ matrix.entry.name }}.gemfile bundle install --jobs 3 --retry 3
+      - name: test
+        run: BUNDLE_GEMFILE=gemfiles/${{ matrix.entry.name }}.gemfile vendor/bats/bin/bats ${{ matrix.entry.bats }}

--- a/Appraisals
+++ b/Appraisals
@@ -23,7 +23,7 @@ end
 appraise "rspec2" do
   # Pin Rake version to Prevent `NoMethodError: undefined method `last_comment'`.
   gem 'rake', '< 11.0'
-  gem 'rspec', '~> 2.13.0'
+  gem 'rspec', '~> 2.99'
 end
 
 appraise "rspec3" do

--- a/gemfiles/rspec2.gemfile
+++ b/gemfiles/rspec2.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rake", "< 11.0"
-gem "rspec", "~> 2.13.0"
+gem "rspec", "~> 2.99"
 
 gemspec path: "../"


### PR DESCRIPTION
That's what was changed in Ruby 3.2 to make CI work.

## RSpec 2 has separate job

RSpec 2 has separate job because RSpec 2 doesn't work with Ruby 3.2:

```console
# /opt/hostedtoolcache/Ruby/3.2.1/x64/lib/ruby/gems/3.2.0/gems/rspec-core-2.99.2/lib/rspec/core/ruby_project.rb:27:
in `block in find_first_parent_containing': undefined method `exists?' for File:Class (NoMethodError)
#
#         ascend_until {|path| File.exists?(File.join(path, dir))}
#                                  ^^^^^^^^
# Did you mean?  exist?
#       from /opt/hostedtoolcache/Ruby/3.2.1/x64/lib/ruby/gems/3.2.0/gems/rspec-core-2.99.2/lib/rspec/core/ruby_project.rb:32:
in `block in ascend_until'
#       from /opt/hostedtoolcache/Ruby/3.2.1/x64/lib/ruby/3.2.0/pathname.rb:331:in `ascend'
```

https://github.com/tmm1/test-queue/actions/runs/4443269714/jobs/7800375435

So RSpec 2 is the last version Ruby 3.1 worked on. This PR updates out-of-development RSpec 2 to 2.99.

## `BUNDLE_GEMFILE` specified in run commands as a workaround

And the value of `BUNDLE_GEMFILE: ${{ matrix.gemfile }}` is empty in Ruby 3.2:

```console
Run bundle exec appraisal minitest5 bundle install
 bundle exec appraisal minitest5 bundle install
 shell: /usr/bin/bash -e {0}
 env:
   BUNDLE_GEMFILE:
   TEST_QUEUE_WORKERS: 2
   TEST_QUEUE_VERBOSE: 1
/opt/hostedtoolcache/Ruby/3.2.1/x64/lib/ruby/3.2.0/bundler/resolver.rb:293:
in `raise_not_found!': Could not find gem 'minitest (= 5.4.3)' in locally installed gems. (Bundler::GemNotFound)
```

https://github.com/tmm1/test-queue/actions/runs/4443064205/jobs/7799958894?pr=106

`BUNDLE_GEMFILE=gemfiles/${{ matrix.entry.name }}.gemfile` is specified in run commands as a workaround.