### PR TITLE
Fix an error for `minitest-queue`

### DIFF
--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -56,6 +56,13 @@ module TestQueue
   class Runner
     class MiniTest < Runner
       def initialize
+        options = Minitest.process_args ARGV
+
+        if Minitest.respond_to?(:seed)
+          Minitest.seed = options[:seed]
+          srand Minitest.seed
+        end
+
         if ::MiniTest::Test.runnables.any? { |r| r.runnable_methods.any? }
           fail "Do not `require` test files. Pass them via ARGV instead and they will be required as needed."
         end


### PR DESCRIPTION
This PR fixes the following error when running `minitest-queue`:

```console
$ bundle exec minitest-queue test/**/*.rb
bundler: failed to load command: minitest-queue (/Users/koic/.rbenv/versions/3.2.1/bin/minitest-queue)
/Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-5.18.0/lib/minitest/test.rb:74:in `srand': no implicit conversion of nil into Integer (TypeError)

        srand Minitest.seed
              ^^^^^^^^^^^^^
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-5.18.0/lib/minitest/test.rb:74:in `runnable_methods'
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/test-queue-0.5.0/lib/test_queue/runner/minitest5.rb:59:in `block in initialize'
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/test-queue-0.5.0/lib/test_queue/runner/minitest5.rb:59:in `any?'
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/test-queue-0.5.0/lib/test_queue/runner/minitest5.rb:59:in `initialize'
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/test-queue-0.5.0/bin/minitest-queue:4:in `new'
        from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/test-queue-0.5.0/bin/minitest-queue:4:in `<top (required)>'
        from /Users/koic/.rbenv/versions/3.2.1/bin/minitest-queue:25:in `load'
        from /Users/koic/.rbenv/versions/3.2.1/bin/minitest-queue:25:in `<top (required)>'
```

And this PR bumps Minitest for testing to a version that fails the test as follows:

```console
% appraisal minitest5 bundle exec rake
>> BUNDLE_GEMFILE=/Users/koic/src/github.com/tmm1/test-queue/gemfiles/minitest5.gemfile bundle exec rake
/Users/koic/.rbenv/versions/3.1.3/bin/ruby -I/Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rspec-core-3.12.1/lib:/Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rspec-support-3.12.0/lib /Users/koic/
.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rspec-core-3.12.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
......

Finished in 0.01097 seconds (files took 0.09175 seconds to load)
6 examples, 0 failures

TEST_QUEUE_WORKERS=2 TEST_QUEUE_VERBOSE=1 vendor/bats/bin/bats test
 - cucumber-queue succeeds when all features pass (skipped: cucumber is not installed)
 - cucumber-queue fails when a feature fails (skipped: cucumber is not installed)
 - cucumber-queue fails when given a missing feature (skipped: cucumber is not installed)
 - cucumber-queue fails when given a malformed feature (skipped: cucumber is not installed)
 - cucumber-queue handles test file being deleted (skipped: cucumber is not installed)
 - minitest-queue succeeds when all tests pass (skipped: minitest 5.18.0 is not ~> 4.0)
 - minitest-queue fails when a test fails (skipped: minitest 5.18.0 is not ~> 4.0)
 - minitest-queue succeeds when all specs pass (skipped: minitest 5.18.0 is not ~> 4.0)
 - minitest-queue fails when a spec fails (skipped: minitest 5.18.0 is not ~> 4.0)
 ✗ minitest-queue (minitest5) succeeds when all tests pass
   (from function `assert_status' in file test/testlib.bash, line 32,
    in test file test/minitest5.bats, line 17)
     `assert_status 0' failed
   Expected status to be 0 but was 1. Full output:
   bundler: failed to load command: minitest-queue (/Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/bin/minitest-queue)
   /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/minitest-5.18.0/lib/minitest/test.rb:74:in `srand': no implicit conversion of nil into Integer (TypeError)
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/minitest-5.18.0/lib/minitest/test.rb:74:in `runnable_methods'
        from /Users/koic/src/github.com/tmm1/test-queue/lib/test_queue/runner/minitest5.rb:59:in `block in initialize'
        from /Users/koic/src/github.com/tmm1/test-queue/lib/test_queue/runner/minitest5.rb:59:in `any?'
        from /Users/koic/src/github.com/tmm1/test-queue/lib/test_queue/runner/minitest5.rb:59:in `initialize'
        from /Users/koic/src/github.com/tmm1/test-queue/exe/minitest-queue:4:in `new'
        from /Users/koic/src/github.com/tmm1/test-queue/exe/minitest-queue:4:in `<top (required)>'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/bin/minitest-queue:25:in `load'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/bin/minitest-queue:25:in `<top (required)>'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/cli/exec.rb:58:in `load'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/cli/exec.rb:58:in `kernel_load'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/cli/exec.rb:23:in `run'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/cli.rb:491:in `exec'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/cli.rb:34:in `dispatch'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/cli.rb:28:in `start'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/exe/bundle:45:in `block in <top (required)>'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /Users/koic/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/exe/bundle:33:in `<top (required)>'
        from /Users/koic/.rbenv/versions/3.1.3/bin/bundle:25:in `load'
        from /Users/koic/.rbenv/versions/3.1.3/bin/bundle:25:in `<main>'
```