### PR TITLE
Run with `spec` directory by default for `rspec-queue` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           - { name: cucumber2_4, bats: test/cucumber.bats }
           - { name: minitest4, bats: test/minitest4.bats }
           - { name: minitest5, bats: test/minitest5.bats }
-          - { name: rspec3, bats: test/rspec.bats }
+          - { name: rspec3, bats: test/rspec3.bats }
           - { name: testunit, bats: test/testunit.bats }
 
     steps:
@@ -71,7 +71,7 @@ jobs:
         # Lowest and Latest version.
         ruby: ['2.7', '3.1']
         entry:
-          - { name: rspec2, bats: test/rspec.bats }
+          - { name: rspec2, bats: test/rspec2.bats }
 
     steps:
       - name: checkout

--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -36,6 +36,11 @@ module TestQueue
         options.parse_options if options.respond_to?(:parse_options)
         options.configure(::RSpec.configuration)
 
+        if ::RSpec.configuration.instance_variable_defined?(:@files_or_directories_to_run) &&
+           ::RSpec.configuration.instance_variable_get(:@files_or_directories_to_run).empty?
+          ::RSpec.configuration.instance_variable_set(:@files_or_directories_to_run, [::RSpec.configuration.default_path])
+        end
+
         ::RSpec.configuration.files_to_run.uniq
       end
 

--- a/test/rspec2.bats
+++ b/test/rspec2.bats
@@ -1,7 +1,7 @@
 load "testlib"
 
 setup() {
-  require_gem "rspec" ">= 2.0"
+  require_gem "rspec" "~> 2.0"
 }
 
 @test "rspec-queue succeeds when all specs pass" {
@@ -43,5 +43,4 @@ setup() {
   run bundle exec rspec-queue ./test/samples/sample_use_shared_example1_spec.rb \
                               ./test/samples/sample_use_shared_example2_spec.rb
   assert_status 0
-
 }

--- a/test/rspec3.bats
+++ b/test/rspec3.bats
@@ -1,0 +1,56 @@
+load "testlib"
+
+setup() {
+  require_gem "rspec" "~> 3.0"
+}
+
+@test "rspec-queue succeeds when all specs pass" {
+  run bundle exec rspec-queue ./test/samples/sample_spec.rb
+  assert_status 0
+  assert_output_contains "Starting test-queue master"
+  assert_output_contains "16 examples, 0 failures"
+  assert_output_contains "16 examples, 0 failures"
+}
+
+@test "rspec-queue succeeds all specs pass in the default spec directory even if directory path is omitted" {
+  run bundle exec rspec-queue
+  assert_status 0
+  assert_output_contains "Starting test-queue master"
+  assert_output_contains "6 examples, 0 failures"
+  assert_output_contains "0 examples, 0 failures"
+}
+
+@test "rspec-queue fails when a spec fails" {
+  export FAIL=1
+  run bundle exec rspec-queue ./test/samples/sample_spec.rb
+  assert_status 1
+  assert_output_contains "1) RSpecFailure fails"
+  assert_output_contains "RSpecFailure fails"
+  assert_output_contains "expected: :bar"
+  assert_output_contains "got: :foo"
+}
+
+@test "TEST_QUEUE_SPLIT_GROUPS splits splittable groups" {
+  export TEST_QUEUE_SPLIT_GROUPS=true
+  run bundle exec rspec-queue ./test/samples/sample_split_spec.rb
+  assert_status 0
+
+  assert_output_matches '\[ 1\] +1 example, 0 failures'
+  assert_output_matches '\[ 2\] +1 example, 0 failures'
+}
+
+@test "TEST_QUEUE_SPLIT_GROUPS does not split unsplittable groups" {
+  export TEST_QUEUE_SPLIT_GROUPS=true
+  export NOSPLIT=1
+  run bundle exec rspec-queue ./test/samples/sample_split_spec.rb
+  assert_status 0
+
+  assert_output_contains "2 examples, 0 failures"
+  assert_output_contains "0 examples, 0 failures"
+}
+
+@test "rspec-queue supports shared example groups" {
+  run bundle exec rspec-queue ./test/samples/sample_use_shared_example1_spec.rb \
+                              ./test/samples/sample_use_shared_example2_spec.rb
+  assert_status 0
+}


### PR DESCRIPTION
## Before

Requrie a target target directory:

```console
$ bundle exec test-queue spec
```

If the `spec` path is omitted, user might be surprised to see 0 test runs.

## After

`spec` directory is target by default when target directory is ommited:

```console
$ bundle exec test-queue
```

So, user can use it in the same abbreviated way as RSpec.

```console
$ bundle exec rspec # spec directory by default target.
```

Note, however, that this PR implementation (i.e. `@files_or_directories_to_run`) is naive as it relies on: https://github.com/rspec/rspec-core/blob/v3.12.1/lib/rspec/core/configuration.rb#L1061-L1077