### PR TITLE
Pin Minitest 5.10.0 for E2E testing

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -17,7 +17,7 @@ end
 
 appraise "minitest5" do
   gem 'rake'
-  gem 'minitest', '5.4.3'
+  gem 'minitest', '5.10.0'
 end
 
 appraise "rspec2" do

--- a/gemfiles/minitest5.gemfile
+++ b/gemfiles/minitest5.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "minitest", "5.4.3"
+gem "minitest", "5.10.0"
 
 gemspec path: "../"

--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -28,11 +28,11 @@ teardown() {
 }
 
 @test "TEST_QUEUE_FORCE allowlists certain tests" {
-  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MiniTestSleep21,MiniTestSleep8"
+  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MiniTestSleep11,MiniTestSleep8"
   run bundle exec minitest-queue ./test/samples/*_minitest5.rb
   assert_status 0
   assert_output_contains "Starting test-queue master"
-  assert_output_contains "MiniTestSleep21"
+  assert_output_contains "MiniTestSleep11"
   assert_output_contains "MiniTestSleep8"
   refute_output_contains "MiniTestSleep9"
 }
@@ -68,7 +68,7 @@ assert_test_queue_force_ordering() {
 }
 
 @test "minitest-queue fails if TEST_QUEUE_FORCE specifies nonexistent tests" {
-  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MiniTestSleep21,DoesNotExist"
+  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MiniTestSleep11,DoesNotExist"
   run bundle exec minitest-queue ./test/samples/*_minitest5.rb
   assert_status 1
   assert_output_contains "Failed to discover DoesNotExist specified in TEST_QUEUE_FORCE"


### PR DESCRIPTION
Pass tests up to Minitest 5.10 by making `MiniTestSleepXx` an early number. It may be related to sleep time.

```console
$ TEST_QUEUE_VERBOSE=1 TEST_QUEUE_WORKERS=2 bundle exec appraisal minitest5 vendor/bats/bin/bats test/minitest5.bats
```

On the other hand, 5.11 does not pass the E2E test due to something below. Further investigation is required. https://github.com/minitest/minitest/compare/v5.10.3..v5.11.0