### PR TITLE
Display seed value when running Minitest 5

### DIFF
--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -56,17 +56,24 @@ module TestQueue
   class Runner
     class MiniTest < Runner
       def initialize
-        options = Minitest.process_args ARGV
+        @options = Minitest.process_args ARGV
 
         if Minitest.respond_to?(:seed)
-          Minitest.seed = options[:seed]
+          Minitest.seed = @options[:seed]
           srand Minitest.seed
         end
 
         if ::MiniTest::Test.runnables.any? { |r| r.runnable_methods.any? }
           fail "Do not `require` test files. Pass them via ARGV instead and they will be required as needed."
         end
+
         super(TestFramework::MiniTest.new)
+      end
+
+      def start_master
+        puts "Run options: #{@options[:args]}\n\n"
+
+        super
       end
 
       def run_worker(iterator)

--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -18,6 +18,21 @@ teardown() {
   assert_output_contains "Starting test-queue master"
 }
 
+@test "minitest-queue (minitest5) succeeds when all tests pass with the --seed option" {
+  run bundle exec minitest-queue --seed 1234 ./test/samples/*_minitest5.rb
+  assert_status 0
+  assert_output_contains "Run options: --seed 1234"
+  assert_output_contains "Starting test-queue master"
+}
+
+@test "minitest-queue (minitest5) succeeds when all tests pass with the SEED env variable" {
+  export SEED=1234
+  run bundle exec minitest-queue ./test/samples/*_minitest5.rb
+  assert_status 0
+  assert_output_contains "Run options: --seed 1234"
+  assert_output_contains "Starting test-queue master"
+}
+
 @test "minitest-queue (minitest5) fails when a test fails" {
   export FAIL=1
   run bundle exec minitest-queue ./test/samples/*_minitest5.rb


### PR DESCRIPTION
Resolves #30.

This PR makes `Runner::MiniTest` display seed value when running Minitest 5 This new feature will not be added to Minitest 4 as MT4 support will be dropped soon.

## Before

```console
$ bundle exec minitest-queue test/**/*_test.rb
Starting test-queue master (/tmp/test_queue_42080_1560.sock)

==> Summary (16 workers in 4.0841s)
(snip)
```

## After

```console
$ bundle exec minitest-queue test/**/*_test.rb
Run options: --seed 36048

Starting test-queue master (/tmp/test_queue_42080_1560.sock)

==> Summary (16 workers in 4.0841s)
(snip)
```