### PR TITLE
Rename `MiniTest` to `Minitest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ minitest-queue $(find test/ -name \*_test.rb)
 $ rspec-queue --format progress spec
 ```
 
-But the underlying `TestQueue::Runner::TestUnit`, `TestQueue::Runner::MiniTest`, and `TestQueue::Runner::RSpec` are
+But the underlying `TestQueue::Runner::TestUnit`, `TestQueue::Runner::Minitest`, and `TestQueue::Runner::RSpec` are
 built to be subclassed by your application. I recommend checking a new
 executable into your project using one of these superclasses.
 
@@ -66,7 +66,7 @@ runner to reset any global state.
 ``` ruby
 #!/usr/bin/env ruby
 
-class MyAppTestRunner < TestQueue::Runner::MiniTest
+class MyAppTestRunner < TestQueue::Runner::Minitest
   def after_fork(num)
     # use separate mysql database (we assume it exists and has the right schema already)
     ActiveRecord::Base.configurations.configs_for(env_name: 'test', name: 'primary').database << num.to_s

--- a/exe/minitest-queue
+++ b/exe/minitest-queue
@@ -5,4 +5,4 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require 'test_queue'
 require 'test_queue/runner/minitest'
 
-TestQueue::Runner::MiniTest.new.execute
+TestQueue::Runner::Minitest.new.execute

--- a/lib/test_queue/runner/minitest.rb
+++ b/lib/test_queue/runner/minitest.rb
@@ -8,7 +8,7 @@ end
 
 module TestQueue
   class Runner
-    class MiniTest < Runner
+    class Minitest < Runner
       def summarize_worker(worker)
         worker.summary = worker.lines.grep(/, \d+ errors?, /).first
         failures  = worker.lines.select{ |line|

--- a/lib/test_queue/runner/minitest4.rb
+++ b/lib/test_queue/runner/minitest4.rb
@@ -55,12 +55,12 @@ end
 
 module TestQueue
   class Runner
-    class MiniTest < Runner
+    class Minitest < Runner
       def initialize
         if ::MiniTest::Unit::TestCase.original_test_suites.any?
           fail "Do not `require` test files. Pass them via ARGV instead and they will be required as needed."
         end
-        super(TestFramework::MiniTest.new)
+        super(TestFramework::Minitest.new)
       end
 
       def run_worker(iterator)
@@ -68,10 +68,11 @@ module TestQueue
         ::MiniTest::Unit.new.run
       end
     end
+    MiniTest = Minitest # For compatibility with test-queue 0.7.0 and earlier.
   end
 
   class TestFramework
-    class MiniTest < TestFramework
+    class Minitest < TestFramework
       def all_suite_files
         ARGV
       end
@@ -84,5 +85,6 @@ module TestQueue
         }
       end
     end
+    MiniTest = Minitest # For compatibility with test-queue 0.7.0 and earlier.
   end
 end

--- a/lib/test_queue/runner/minitest5.rb
+++ b/lib/test_queue/runner/minitest5.rb
@@ -1,6 +1,6 @@
 require_relative '../runner'
 
-module MiniTest
+module Minitest
   def self.__run reporter, options
     suites = Runnable.runnables
     suites.map { |suite| suite.run reporter, options }
@@ -54,20 +54,19 @@ end
 
 module TestQueue
   class Runner
-    class MiniTest < Runner
+    class Minitest < Runner
       def initialize
-        @options = Minitest.process_args ARGV
+        @options = ::Minitest.process_args ARGV
 
-        if Minitest.respond_to?(:seed)
-          Minitest.seed = @options[:seed]
-          srand Minitest.seed
+        if ::Minitest.respond_to?(:seed)
+          ::Minitest.seed = @options[:seed]
+          srand ::Minitest.seed
         end
 
-        if ::MiniTest::Test.runnables.any? { |r| r.runnable_methods.any? }
+        if ::Minitest::Test.runnables.any? { |r| r.runnable_methods.any? }
           fail "Do not `require` test files. Pass them via ARGV instead and they will be required as needed."
         end
-
-        super(TestFramework::MiniTest.new)
+        super(TestFramework::Minitest.new)
       end
 
       def start_master
@@ -77,25 +76,27 @@ module TestQueue
       end
 
       def run_worker(iterator)
-        ::MiniTest::Test.runnables = iterator
-        ::MiniTest.run ? 0 : 1
+        ::Minitest::Test.runnables = iterator
+        ::Minitest.run ? 0 : 1
       end
     end
+    MiniTest = Minitest # For compatibility with test-queue 0.7.0 and earlier.
   end
 
   class TestFramework
-    class MiniTest < TestFramework
+    class Minitest < TestFramework
       def all_suite_files
         ARGV
       end
 
       def suites_from_file(path)
-        ::MiniTest::Test.reset
+        ::Minitest::Test.reset
         require File.absolute_path(path)
-        ::MiniTest::Test.runnables
+        ::Minitest::Test.runnables
           .reject { |s| s.runnable_methods.empty? }
           .map { |s| [s.name, s] }
       end
     end
+    MiniTest = Minitest # For compatibility with test-queue 0.7.0 and earlier.
   end
 end

--- a/test/examples/example_minitest4.rb
+++ b/test/examples/example_minitest4.rb
@@ -1,13 +1,13 @@
 require 'minitest/unit'
 
-class MiniTestEqual < MiniTest::Unit::TestCase
+class MinitestEqual < MiniTest::Unit::TestCase
   def test_equal
     assert_equal 1, 1
   end
 end
 
 30.times do |i|
-  Object.const_set("MiniTestSleep#{i}", Class.new(MiniTest::Unit::TestCase) do
+  Object.const_set("MinitestSleep#{i}", Class.new(Minitest::Unit::TestCase) do
     define_method('test_sleep') do
       start = Time.now
       sleep(0.25)
@@ -17,7 +17,7 @@ end
 end
 
 if ENV["FAIL"]
-  class MiniTestFailure < MiniTest::Unit::TestCase
+  class MinitestFailure < MiniTest::Unit::TestCase
     def test_fail
       assert_equal 0, 1
     end

--- a/test/examples/example_minitest5.rb
+++ b/test/examples/example_minitest5.rb
@@ -1,13 +1,13 @@
 require 'minitest/autorun'
 
-class MiniTestEqual < MiniTest::Test
+class MinitestEqual < Minitest::Test
   def test_equal
     assert_equal 1, 1
   end
 end
 
 30.times do |i|
-  Object.const_set("MiniTestSleep#{i}", Class.new(MiniTest::Test) do
+  Object.const_set("MinitestSleep#{i}", Class.new(Minitest::Test) do
     define_method('test_sleep') do
       start = Time.now
       sleep(0.25)
@@ -17,7 +17,7 @@ end
 end
 
 if ENV["FAIL"]
-  class MiniTestFailure < MiniTest::Test
+  class MinitestFailure < Minitest::Test
     def test_fail
       assert_equal 0, 1
     end
@@ -25,7 +25,7 @@ if ENV["FAIL"]
 end
 
 if ENV["KILL"]
-  class MiniTestKilledFailure < MiniTest::Test
+  class MinitestKilledFailure < Minitest::Test
     def test_kill
       Process.kill(9, $$)
     end

--- a/test/minitest4.bats
+++ b/test/minitest4.bats
@@ -16,7 +16,7 @@ setup() {
   assert_status 1
   assert_output_contains "Starting test-queue master"
   assert_output_contains "1) Failure:"
-  assert_output_contains "MiniTestFailure#test_fail"
+  assert_output_contains "MinitestFailure#test_fail"
 }
 
 @test "minitest-queue succeeds when all specs pass" {

--- a/test/minitest5.bats
+++ b/test/minitest5.bats
@@ -39,17 +39,17 @@ teardown() {
   assert_status 1
   assert_output_contains "Starting test-queue master"
   assert_output_contains "1) Failure:"
-  assert_output_contains "MiniTestFailure#test_fail"
+  assert_output_contains "MinitestFailure#test_fail"
 }
 
 @test "TEST_QUEUE_FORCE allowlists certain tests" {
-  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MiniTestSleep11,MiniTestSleep8"
+  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MinitestSleep11,MinitestSleep8"
   run bundle exec minitest-queue ./test/examples/*_minitest5.rb
   assert_status 0
   assert_output_contains "Starting test-queue master"
-  assert_output_contains "MiniTestSleep11"
-  assert_output_contains "MiniTestSleep8"
-  refute_output_contains "MiniTestSleep9"
+  assert_output_contains "MinitestSleep11"
+  assert_output_contains "MinitestSleep8"
+  refute_output_contains "MinitestSleep9"
 }
 
 assert_test_queue_force_ordering() {
@@ -69,7 +69,7 @@ assert_test_queue_force_ordering() {
 }
 
 @test "TEST_QUEUE_FORCE ensures test ordering" {
-  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="Meme::when asked about cheeseburgers,MiniTestEqual"
+  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="Meme::when asked about cheeseburgers,MinitestEqual"
 
   # Without stats file
   rm -f .test_queue_stats
@@ -83,7 +83,7 @@ assert_test_queue_force_ordering() {
 }
 
 @test "minitest-queue fails if TEST_QUEUE_FORCE specifies nonexistent tests" {
-  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MiniTestSleep11,DoesNotExist"
+  export TEST_QUEUE_WORKERS=1 TEST_QUEUE_FORCE="MinitestSleep11,DoesNotExist"
   run bundle exec minitest-queue ./test/examples/*_minitest5.rb
   assert_status 1
   assert_output_contains "Failed to discover DoesNotExist specified in TEST_QUEUE_FORCE"
@@ -125,7 +125,7 @@ assert_test_queue_force_ordering() {
   assert_status 1
   assert_output_contains "Starting test-queue master"
   assert_output_contains "1) Failure:"
-  assert_output_contains "MiniTestFailure#test_fail"
+  assert_output_contains "MinitestFailure#test_fail"
 }
 
 @test "multi-master remote master fails when a test fails" {
@@ -140,7 +140,7 @@ assert_test_queue_force_ordering() {
   assert_status 1
   assert_output_contains "Starting test-queue master"
   assert_output_contains "1) Failure:"
-  assert_output_contains "MiniTestFailure#test_fail"
+  assert_output_contains "MinitestFailure#test_fail"
 }
 
 @test "multi-master central master prints out remote master messages" {

--- a/test/sleepy_runner.rb
+++ b/test/sleepy_runner.rb
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require 'test_queue'
 require 'test_queue/runner/minitest'
 
-class SleepyTestRunner < TestQueue::Runner::MiniTest
+class SleepyTestRunner < TestQueue::Runner::Minitest
   def after_fork(num)
     if ENV['SLEEP_AS_RELAY'] && relay?
       sleep 5


### PR DESCRIPTION
Follow up https://github.com/minitest/minitest/commit/9a57c520

This PR renames `TestQueue::MiniTest::Runner` to  `TestQueue::Minitest::Runner` and `TestQueue::MiniTest::TestFramework` to `TestQueue::Minitest::TestFramework`.

For compatibility with 0.7 and earlier, it is also available in `TestQueue::MiniTest::Runner` and `TestQueue::MiniTest::TestFramework`.