### PR TITLE
Extract version of test-queue from gemspec to module constant

### DIFF
--- a/lib/test_queue/version.rb
+++ b/lib/test_queue/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module TestQueue
+  VERSION = '0.7.0'
+end

--- a/test-queue.gemspec
+++ b/test-queue.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative 'lib/test_queue/version'
+
 Gem::Specification.new do |s|
   s.name = 'test-queue'
-  s.version = '0.7.0'
+  s.version = TestQueue::VERSION
   s.required_ruby_version = '>= 2.7.0'
   s.summary = 'parallel test runner'
   s.description = 'minitest/rspec parallel test runner for CI environments'


### PR DESCRIPTION
This PR extracts version of test-queue from gemspec to module constant. It is general gem structure.