### PR TITLE
Gather development scripts into `bin` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.bundle
 .test_queue_stats
 .ruby-version
 Gemfile.lock

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ RuboCop::RakeTask.new
 task default: [:setup, :rubocop, :spec, :feature]
 
 task :setup do
-  sh 'script/bootstrap' unless File.exist?("#{Dir.pwd}/vendor/bats/bin/bats")
+  sh 'bin/setup' unless File.exist?("#{Dir.pwd}/vendor/bats/bin/bats")
 end
 
 task :feature do

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'irb'
+require 'test_queue'
+
+ARGV.clear
+
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -11,3 +11,5 @@ mkdir -p vendor/bats
 curl --silent --location --show-error https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz | tar -xz -C tmp
 tmp/bats-0.4.0/install.sh "$ROOT/vendor/bats"
 rm -rf tmp
+
+bundle install --jobs 3 --retry 3


### PR DESCRIPTION
This PR adds `bin/console` and moves `script/bootstrap` to `bin/setup`, both of which are development scripts.