### PR TITLE
Display seed value when running RSpec

### DIFF
--- a/lib/test_queue/runner/rspec.rb
+++ b/lib/test_queue/runner/rspec.rb
@@ -12,16 +12,30 @@ module TestQueue
     class RSpec < Runner
       def initialize
         super(TestFramework::RSpec.new)
+
+        @rspec = ::RSpec::Core::QueueRunner.new
+      end
+
+      def start_master
+        seed_notification = ::RSpec::Core::Notifications::SeedNotification.new(@rspec.configuration.seed, seed_used?)
+        puts "#{seed_notification.fully_formatted}\n"
+
+        super
       end
 
       def run_worker(iterator)
-        rspec = ::RSpec::Core::QueueRunner.new
-        rspec.run_each(iterator).to_i
+        @rspec.run_each(iterator).to_i
       end
 
       def summarize_worker(worker)
         worker.summary = worker.lines.grep(/ examples?, /).first
         worker.failure_output = worker.output[/^Failures:\n\n(.*)\n^Finished/m, 1]
+      end
+
+      private
+
+      def seed_used?
+        @rspec.configuration.seed && @rspec.configuration.seed_used?
       end
     end
   end

--- a/test/rspec3.bats
+++ b/test/rspec3.bats
@@ -7,6 +7,7 @@ setup() {
 @test "rspec-queue succeeds when all specs pass" {
   run bundle exec rspec-queue ./test/examples/example_spec.rb
   assert_status 0
+  assert_output_contains "Randomized with seed"
   assert_output_contains "Starting test-queue master"
   assert_output_contains "16 examples, 0 failures"
   assert_output_contains "16 examples, 0 failures"

--- a/test/rspec4.bats
+++ b/test/rspec4.bats
@@ -7,6 +7,7 @@ setup() {
 @test "rspec-queue succeeds when all specs pass" {
   run bundle exec rspec-queue ./test/examples/example_spec.rb
   assert_status 0
+  assert_output_contains "Randomized with seed"
   assert_output_contains "Starting test-queue master"
   assert_output_contains "16 examples, 0 failures"
   assert_output_contains "16 examples, 0 failures"


### PR DESCRIPTION
Issue solving similar to #113.

This PR makes `Runner::RSpec` display seed value when running RSpec.

## Before

```console
$ bundle exec rspec-queue
Starting test-queue master (/tmp/test_queue_42080_1560.sock)

==> Summary (16 workers in 4.0841s)
(snip)
```

## After

```console
$ bundle exec rspec-queue
Randomized with seed 27022

Starting test-queue master (/tmp/test_queue_42080_1560.sock)

==> Summary (16 workers in 4.0841s)
(snip)
```