### PR TITLE
Fix marshal load error when marshal data includes "\n"

### DIFF
--- a/test/examples/example_testunit.rb
+++ b/test/examples/example_testunit.rb
@@ -8,6 +8,12 @@ class TestUnitEqual < Test::Unit::TestCase
   end
 end
 
+class Short < Test::Unit::TestCase
+  def test_work_with_short_class_name
+    assert true
+  end
+end
+
 30.times do |i|
   Object.const_set("TestUnitSleep#{i}", Class.new(Test::Unit::TestCase) do
     define_method(:test_sleep) do


### PR DESCRIPTION
test_queue fails when bytesize of `suite_name` is 5.
Because marshal data includes "\n".

```ruby
require 'test/unit'

class Aiueo < Test::Unit::TestCase
  def test_ok
    assert true
  end
end
```

```console
$ exe/testunit-queue t.rb
Starting test-queue master (/tmp/test_queue_98954_380.sock)
<internal:marshal>:34:in `load': marshal data too short (ArgumentError)
	from /.../lib/test_queue/runner.rb:511:in `distribute_queue'
	from /.../lib/test_queue/runner.rb:228:in `execute_internal'
	from /.../lib/test_queue/runner.rb:119:in `execute'
	from exe/testunit-queue:9:in `<main>'
```