### PR TITLE
Add TEST_QUEUE_SPLIT_GROUPS feature to testunit runner

### DIFF
--- a/lib/test_queue/runner/testunit.rb
+++ b/lib/test_queue/runner/testunit.rb
@@ -4,57 +4,65 @@ require_relative '../runner'
 
 gem 'test-unit'
 require 'test/unit'
-require 'test/unit/collector/descendant'
-require 'test/unit/testresult'
-require 'test/unit/testsuite'
+require 'test/unit/collector/load'
 require 'test/unit/ui/console/testrunner'
-
-class Test::Unit::TestSuite
-  attr_accessor :iterator
-
-  def run(result, &progress_block)
-    @start_time = Time.now
-    yield(STARTED, name)
-    yield(STARTED_OBJECT, self)
-    run_startup(result)
-    (@iterator || @tests).each do |test|
-      @n_tests += test.size
-      run_test(test, result, &progress_block)
-      @passed = false unless test.passed?
-    end
-    run_shutdown(result)
-  ensure
-    @elapsed_time = Time.now - @start_time
-    yield(FINISHED, name)
-    yield(FINISHED_OBJECT, self)
-  end
-
-  def failure_count
-    (@iterator || @tests).sum { |t| t.instance_variable_get(:@_result).failure_count }
-  end
-end
 
 module TestQueue
   class Runner
     class TestUnit < Runner
-      def initialize
-        if Test::Unit::Collector::Descendant.new.collect.tests.any?
-          raise 'Do not `require` test files. Pass them via ARGV instead and they will be required as needed.'
+      class TestSuite < ::Test::Unit::TestSuite
+        def initialize(name, iterator)
+          super(name)
+          @tests = IteratorWrapper.new(iterator)
         end
 
+        def run(*)
+          @started = true
+          super
+        end
+
+        def size
+          return 0 unless @started
+
+          super
+        end
+      end
+
+      class IteratorWrapper
+        def initialize(iterator)
+          @generator = Fiber.new do
+            iterator.each do |test|
+              Fiber.yield(test)
+            end
+          end
+        end
+
+        def shift
+          @generator.resume
+        rescue FiberError
+          nil
+        end
+
+        def each
+          while (test = shift)
+            yield(test)
+          end
+        end
+      end
+
+      def initialize
         super(TestFramework::TestUnit.new)
       end
 
       def run_worker(iterator)
-        @suite = Test::Unit::TestSuite.new('specified by test-queue master')
-        @suite.iterator = iterator
+        @suite = TestSuite.new('specified by test-queue master', iterator)
         res = Test::Unit::UI::Console::TestRunner.new(@suite).start
         res.run_count - res.pass_count
       end
 
       def summarize_worker(worker)
         worker.summary = worker.output.split("\n").grep(/^\d+ tests?/).first
-        worker.failure_output = worker.output.scan(/^Failure:\n(.*)\n=======================*/m).join("\n")
+        worker.failure_output = worker.output.scan(/^Failure:[^\n]*\n(.*?)\n=======================*/m).join("\n")
       end
     end
   end
@@ -66,11 +74,39 @@ module TestQueue
       end
 
       def suites_from_file(path)
-        Test::Unit::TestCase::DESCENDANTS.clear
-        require File.absolute_path(path)
-        Test::Unit::Collector::Descendant.new.collect.tests.map { |suite|
-          [suite.name, suite]
-        }
+        test_suite = Test::Unit::Collector::Load.new.collect(path)
+        return [] unless test_suite
+        return test_suite.tests.map { [_1.name, _1] } unless split_groups?
+
+        split_groups(test_suite)
+      end
+
+      def split_groups?
+        return @split_groups if defined?(@split_groups)
+
+        @split_groups = ENV['TEST_QUEUE_SPLIT_GROUPS'] && ENV['TEST_QUEUE_SPLIT_GROUPS'].strip.downcase == 'true'
+      end
+
+      def split_groups(test_suite, groups = [])
+        unless splittable?(test_suite)
+          groups << [test_suite.name, test_suite]
+          return groups
+        end
+
+        test_suite.tests.each do |suite|
+          if suite.is_a?(Test::Unit::TestSuite)
+            split_groups(suite, groups)
+          else
+            groups << [suite.name, suite]
+          end
+        end
+        groups
+      end
+
+      def splittable?(test_suite)
+        test_suite.tests.none? do |test|
+          test.is_a?(Test::Unit::TestCase) && test[:no_split]
+        end
       end
     end
   end

--- a/test/examples/example_testunit_split.rb
+++ b/test/examples/example_testunit_split.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+
+class SplittableTestCase < Test::Unit::TestCase
+  def wait
+    # Sleep longer in CI to make the distribution of examples across workers
+    # more deterministic.
+    if ENV['CI']
+      sleep(5)
+    else
+      sleep(1)
+    end
+  end
+
+  sub_test_case 'splittable sub_test_case 1' do
+    test 'test 1' do
+      wait
+      assert true
+    end
+
+    sub_test_case 'splittable sub_test_case 2' do
+      attribute :no_split, !!ENV['NOSPLIT'], keep: true
+
+      test 'test 3' do
+        wait
+        assert true
+      end
+
+      test 'test 4' do
+        wait
+        assert true
+      end
+
+      test 'test 5' do
+        wait
+        assert true
+      end
+    end
+  end
+end

--- a/test/testunit.bats
+++ b/test/testunit.bats
@@ -18,3 +18,22 @@ setup() {
   assert_output_contains "Failure:"
   assert_output_contains "test_fail(TestUnitFailure)"
 }
+
+@test "TEST_QUEUE_SPLIT_GROUPS testunit-queue splits splittable sub_test_cases" {
+  export TEST_QUEUE_SPLIT_GROUPS=true
+  run bundle exec testunit-queue ./test/examples/example_testunit_split.rb
+  assert_status 0
+
+  assert_output_matches '\[ 1\] +2 tests,'
+  assert_output_matches '\[ 2\] +2 tests,'
+}
+
+@test "TEST_QUEUE_SPLIT_GROUPS does not testunit-queue splits splittable sub_test_cases" {
+  export TEST_QUEUE_SPLIT_GROUPS=true
+  export NOSPLIT=true
+  run bundle exec testunit-queue ./test/examples/example_testunit_split.rb
+  assert_status 0
+
+  assert_output_matches '\[ .\] +1 tests,'
+  assert_output_matches '\[ .\] +3 tests,'
+}


### PR DESCRIPTION
This PR add split groups feature to test-unit runner, and fix error on nested sub_test_cases.
Current version of testunit-queue fails when nested sub_test_cases exists.

```ruby
# t.rb
require 'test/unit'

class NestedTestCase < Test::Unit::TestCase
  sub_test_case 'sub_test_case 1' do
    test 'test 1' do
      assert true
    end
  end
end
```

```console
$ TEST_QUEUE_WORKERS=1 testunit-queue test/examples/example_testunit_split.rb
Starting test-queue master (/tmp/test_queue_96944_460.sock)

==> Starting test-queue worker [1] (96960 on mini2023.local) - iterating over /tmp/test_queue_96944_460.sock

Loaded suite specified by test-queue master
Started
Finished in 0.103876 seconds.
-------------------------------------------------------------------------------
1 tests, 1 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------
9.63 tests/s, 9.63 assertions/s
/.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner/testunit.rb:33:in `block in failure_count': undefined method `failure_count' for nil:NilClass (NoMethodError)

    (@iterator || @tests).sum { |t| t.instance_variable_get(:@_result).failure_count }
                                                                      ^^^^^^^^^^^^^^
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner/testunit.rb:33:in `sum'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner/testunit.rb:33:in `failure_count'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/iterator.rb:71:in `block in each'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/iterator.rb:29:in `loop'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/iterator.rb:29:in `each'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner/testunit.rb:20:in `run'
	from /.../lib/ruby/gems/3.2.0/gems/test-unit-3.6.1/lib/test/unit/ui/testrunnermediator.rb:67:in `run_suite'
	from /.../lib/ruby/gems/3.2.0/gems/test-unit-3.6.1/lib/test/unit/ui/testrunnermediator.rb:45:in `block (2 levels) in run'
	from /.../lib/ruby/gems/3.2.0/gems/test-unit-3.6.1/lib/test/unit/ui/testrunnermediator.rb:102:in `with_listener'
	from /.../lib/ruby/gems/3.2.0/gems/test-unit-3.6.1/lib/test/unit/ui/testrunnermediator.rb:41:in `block in run'
	from /.../lib/ruby/gems/3.2.0/gems/test-unit-3.6.1/lib/test/unit/ui/testrunnermediator.rb:39:in `catch'
	from /.../lib/ruby/gems/3.2.0/gems/test-unit-3.6.1/lib/test/unit/ui/testrunnermediator.rb:39:in `run'
	from /.../lib/ruby/gems/3.2.0/gems/test-unit-3.6.1/lib/test/unit/ui/testrunner.rb:40:in `start_mediator'
	from /.../lib/ruby/gems/3.2.0/gems/test-unit-3.6.1/lib/test/unit/ui/testrunner.rb:25:in `start'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner/testunit.rb:51:in `run_worker'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner.rb:290:in `block (2 levels) in spawn_workers'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner.rb:285:in `fork'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner.rb:285:in `block in spawn_workers'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner.rb:282:in `times'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner.rb:282:in `spawn_workers'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner.rb:227:in `execute_internal'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/lib/test_queue/runner.rb:119:in `execute'
	from /.../lib/ruby/gems/3.2.0/gems/test-queue-0.9.0/exe/testunit-queue:9:in `<top (required)>'
	from /.../bin/testunit-queue:25:in `load'
	from /.../bin/testunit-queue:25:in `<main>'

==> Summary (1 workers in 0.1108s)

    [ 1] 1 tests, 1 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications         1 suites in 0.1088s      (pid 96960 exit 1 )
```