### PR TITLE
Use Process::fork in place of fork

### DIFF
--- a/lib/test_queue/runner.rb
+++ b/lib/test_queue/runner.rb
@@ -282,7 +282,7 @@ module TestQueue
       @concurrency.times do |i|
         num = i + 1
 
-        pid = fork do
+        pid = Process.fork do
           @server&.close
 
           iterator = Iterator.new(@test_framework, relay? ? @relay : @socket, method(:around_filter), early_failure_limit: @early_failure_limit, run_token: @run_token)


### PR DESCRIPTION
to make it easier to override the default behaviour of fork
if needed.

SimpleCov, for example, does this when [working with subprocesses](https://github.com/simplecov-ruby/simplecov?tab=readme-ov-file#running-simplecov-against-subprocesses).

> SimpleCov.enable_for_subprocesses will allow SimpleCov to observe subprocesses starting using Process.fork. This modifies ruby's core Process.fork method so that SimpleCov can see into it...