### PR TITLE
Use Ruby 3.4 in the latest version of CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        # Lowest and Latest version.
-        ruby: ['2.7', '3.3']
+        # Lowest and Latest versions.
+        ruby: ['2.7', '3.4']
         entry:
           - { name: cucumber1_3, bats: test/cucumber.bats }
           - { name: cucumber2_4, bats: test/cucumber.bats }

--- a/gemfiles/cucumber1_3.gemfile
+++ b/gemfiles/cucumber1_3.gemfile
@@ -5,6 +5,7 @@
 source 'https://rubygems.org'
 
 gem 'cucumber', '~> 1.3.10'
+gem 'drb'
 gem 'rake', '< 11.0'
 gem 'rspec', '>= 2.13', '< 4.0'
 

--- a/gemfiles/minitest5.gemfile
+++ b/gemfiles/minitest5.gemfile
@@ -5,5 +5,6 @@
 source 'https://rubygems.org'
 
 gem 'minitest', '5.10.0'
+gem 'mutex_m'
 
 gemspec path: '../'


### PR DESCRIPTION
This PR uses Ruby 3.4 in the latest version of CI.