### PR TITLE
Fix testunit CI hang by requiring test-unit >= 3.7.4

### DIFF
--- a/gemfiles/testunit.gemfile
+++ b/gemfiles/testunit.gemfile
@@ -4,6 +4,9 @@
 
 source 'https://rubygems.org'
 
-gem 'test-unit'
+# test-unit 3.7.4 changed `TestSuite#run` method signature.
+# Earlier versions cause ArgumentError in test-queue's TestSuite subclass,
+# crashing workers and causing the master process to hang indefinitely.
+gem 'test-unit', '>= 3.7.4'
 
 gemspec path: '../'


### PR DESCRIPTION
The 3.3 testunit CI job was hanging for 6 hours and timing out.

## Problem
test-unit 3.7.4 changed the TestSuite#run method signature

- 3.7.3: run(result, run_context: nil, &block)
- 3.7.4+: run(worker_context, &block)

test-queue's TestSuite subclass uses `def run(*); super; end`, which fails on 3.7.3 when test-unit internally calls run with 2 arguments:

```bash
ArgumentError: wrong number of arguments (given 2, expected 1)
```

The worker process crashes, but the master process keeps waiting indefinitely, causing the hang.

## Reproduction
```bash
gem install test-unit -v 3.7.3
BUNDLE_GEMFILE=gemfiles/testunit.gemfile bundle exec testunit-queue ./test/examples/*_testunit.rb

gem install test-unit -v 3.7.5
BUNDLE_GEMFILE=gemfiles/testunit.gemfile bundle exec testunit-queue ./test/examples/*_testunit.rb
```

## Solution
Pin test-unit to >= 3.7.4 in gemfiles/testunit.gemfile.